### PR TITLE
Streamline README and user documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,282 +2,97 @@
 
 [![Tests](https://github.com/lucaperl/paperless-local-ai/actions/workflows/test.yml/badge.svg)](https://github.com/lucaperl/paperless-local-ai/actions/workflows/test.yml)
 
-CPU-first selective OCR and local metadata automation for Paperless-ngx.
+Selective OCR and local AI metadata automation for Paperless-ngx — built for small CPU-only homeservers.
 
-`paperless-local-ai` is a companion application for people who already run **Paperless-ngx** and **Ollama**. It can re-OCR scan-like PDF pages with PaddleOCR, classify document metadata with a small local text model, and surface genuinely new correspondent names through Paperless' native Suggestions UI for human approval.
+`paperless-local-ai` uses **PaddleOCR** for scanned pages and a local **Ollama** model to classify title, document type, date, tags and correspondents. Normal runtime settings, prompts and tests are handled through the included **Prompt Studio** web UI.
 
-It does **not** replace Paperless, bundle Ollama, modify original PDF files, or auto-create new correspondents.
-
-> **Release status:** `0.1.0`. The complete workflow is production-tested with Paperless-ngx **3.0.5** on **linux/amd64**. The native suggestion bridge is intentionally version-sensitive; do not assume a newer Paperless release is compatible until it has been tested.
->
-> **Language note:** the Studio UI and the shipped default prompts are German in `0.1.0`. OCR language is configurable, and prompts can be edited in the Studio, but non-German end-to-end behavior is not yet claimed as tested.
-
-## Why this exists
-
-Paperless already provides OCR and metadata tools. This project adds a deliberately small post-processing pipeline for a different operating point:
-
-- keep trustworthy native PDF text instead of OCRing everything again;
-- distrust hidden OCR layers on scan-like pages and run PaddleOCR where the page structure indicates it is needed;
-- use a small **text-only** Ollama model for metadata instead of a vision model for every document;
-- serialize heavy OCR/LLM work so low-power homeservers are not overloaded;
-- keep final review in Paperless.
-
-## How the pipeline works
+## How it works
 
 ```text
-Paperless imports a document
-        |
-        | workflow adds the configured OCR queue tag
-        v
-ocr-worker
-        |
-        | per page
-        |-- trustworthy native text --> keep native text
-        |-- scan / sandwich PDF ------> PaddleOCR that page
-        |-- ambiguous page -----------> OCR for verification
-        |
-        | updates Paperless extracted content when justified
-        | hands document to LLM queue
-        v
-metadata-worker
-        |
-        |-- main structured classification
-        |     title / document type / tags / date / existing correspondent
-        |
-        `-- optional correspondent-only fallback
-              exact existing name --> apply
-              genuinely new name --> save review candidate
-                                      (never auto-create)
-        v
-Paperless metadata + Inbox/review
-
-Paperless native AI Suggestions request
-        |
-        v
-suggestion-bridge
-        |
-        | preserves classic Paperless suggestions
-        ` adds one uniquely matched open correspondent candidate
-        v
-Human accepts/rejects inside Paperless
+Paperless import
+      ↓
+PaddleOCR when needed
+      ↓
+Local LLM classification
+      ↓
+Title · Type · Date · Tags · Correspondent
+      ↓
+Paperless review
 ```
 
-The original file stored by Paperless is not replaced. The OCR worker changes Paperless' extracted `content` only.
+Native PDF text is kept. Scan-like pages — even if they already contain an unreliable OCR text layer — are reprocessed with PaddleOCR.
 
-## Components
+The main classifier uses the existing Paperless taxonomy instead of inventing arbitrary values.
 
-One Compose project runs four long-lived services from two images:
+### Correspondents
 
-| Service | Image | Purpose |
-|---|---|---|
-| `ocr-worker` | `paperless-local-ai-ocr` | PDF page analysis and PaddleOCR |
-| `metadata-worker` | `paperless-local-ai-core` | metadata classification and optional correspondent fallback |
-| `prompt-ui` | `paperless-local-ai-core` | central settings/prompt/testing UI |
-| `suggestion-bridge` | `paperless-local-ai-core` | adapter for Paperless 3.0.5 native correspondent review |
+The main classification pass only uses existing Paperless correspondents. If none can be resolved, an optional **second, correspondent-only LLM pass** runs:
 
-Ollama stays external and is never started by this Compose project.
+```text
+existing correspondent → apply automatically
+new correspondent      → suggest for review in Paperless
+```
+
+New correspondents are never created automatically.
+
+## Prompt Studio
+
+The web UI controls the normal application workflow:
+
+- Paperless and Ollama connections
+- OCR settings
+- queue and review tags
+- classification prompt and model
+- correspondent fallback prompt and model
+- testing, history, polling and dry-run
+
+## Why this project?
+
+This project grew out of running local document AI on modest CPU-only hardware.
+
+Two things became bottlenecks:
+
+- **OCR quality:** on the documents that motivated this project, Tesseract OCR was often not clean enough as input for a small local LLM. Scan-like pages are therefore selectively reprocessed with PaddleOCR.
+- **Inference time:** per-field LLM workflows such as the one used by `paperless-gpt` were too slow on the reference CPU because prompt processing was repeated several times per document.
+
+`paperless-local-ai` combines title, document type, date, tags and existing correspondent classification into **one structured LLM request**. Only the unresolved-correspondent case can add a second, specialized request.
+
+The scope is deliberately narrow: **better OCR and automatic metadata classification**. AI-heavy extras such as document chat, RAG or semantic search are left out because they add complexity and are a poor fit for the low-power hardware this project targets.
+
+Paperless' native AI is a general suggestion feature; this project is instead designed as an automatic, queue-driven pipeline with selective OCR, constrained taxonomy values and predictable resource use.
+
+## Reference system
+
+**Intel Core i3-8100 · 16 GB RAM · no GPU · qwen3.5:4b**
+
+Real production examples:
+
+| Task | Time |
+|---|---:|
+| Normal scanned document — OCR | ~112 s |
+| Metadata classification | ~65 s |
+| Optional correspondent fallback | ~39 s |
+
+These are example document measurements, not performance guarantees.
 
 ## Requirements
 
-For the currently tested release:
+Paperless-ngx · Ollama · Docker Compose or TrueNAS SCALE · linux/amd64
 
-- Paperless-ngx **3.0.5**;
-- Docker Engine with Docker Compose v2, or a Compose-capable platform such as a TrueNAS Custom App;
-- an existing Ollama server reachable from the containers;
-- the configured Ollama model installed there (`qwen3.5:4b` is the shipped default);
-- linux/amd64 for the published OCR image;
-- about 6 GiB of RAM available to the OCR container with the tested defaults.
+Tested with **Paperless-ngx 3.0.5**, **TrueNAS SCALE 25.10.4** and **qwen3.5:4b**. See [Compatibility](docs/compatibility.md) for the exact tested scope.
 
-See [Compatibility](docs/compatibility.md) before using another Paperless version or architecture.
+## Install
 
-## Quick start — normal Docker Compose
-
-### 1. Get the deployment files
-
-```bash
-git clone https://github.com/lucaperl/paperless-local-ai.git
-cd paperless-local-ai
-cp .env.example .env
-```
-
-If you do not want Git installed on the server, download the source archive for the release and use its `compose.yaml` and `.env.example` instead.
-
-### 2. Create a Paperless API token
-
-In Paperless open **My Profile** and create/regenerate an API token. Put it in `.env`:
-
-```text
-PAPERLESS_TOKEN=...
-```
-
-Use a Paperless user that is allowed to read and update the documents and taxonomy this app will manage. See [Paperless setup](docs/paperless-setup.md).
-
-### 3. Review deployment settings
-
-The upstream images are already the default:
-
-```text
-IMAGE_PREFIX=ghcr.io/lucaperl/paperless-local-ai
-APP_VERSION=stable
-```
-
-`stable` tracks the newest non-prerelease release. Pin `APP_VERSION=0.1.0` if you prefer a reproducible deployment that never moves automatically.
-
-Set `APP_DATA_DIR` to a persistent directory and review the bind addresses/ports. The Studio has **no built-in authentication**, so its default bind is localhost.
-
-### 4. Start only the Studio
-
-```bash
-docker compose up -d prompt-ui
-```
-
-Open the Studio. If you want to reach it from another machine, first change `PROMPT_UI_BIND` in `.env` to a trusted LAN address and recreate the service.
-
-Configure **App-Einstellungen**:
-
-- Paperless URL;
-- Ollama URL;
-- queue/error/review tag names;
-- OCR language/version/device;
-- polling and review cleanup;
-- dry-run mode.
-
-Important networking rule: URLs are resolved **from inside the containers**. `http://localhost:...` therefore means the current container, not your Docker host. Use a DNS name or IP address that the app containers can actually reach.
-
-### 5. Prepare Paperless
-
-Create the technical tags and the import workflow from [docs/paperless-setup.md](docs/paperless-setup.md).
-
-### 6. Review the two LLM stages
-
-In the Studio:
-
-- **Klassifizierung** owns the main metadata prompt and model parameters;
-- **Korrespondent-Vorschlag** owns a separate correspondent-only prompt and model parameters.
-
-The correspondent fallback is **disabled on a fresh install**. Test it manually before enabling `Produktiv verwenden`.
-
-### 7. Start the complete app and run the doctor
-
-```bash
-docker compose up -d
-docker compose --profile tools run --rm doctor
-```
-
-Then import **one normal test document** before processing a larger archive.
-
-### 8. Optional: native new-correspondent review
-
-If a new correspondent should appear in Paperless' native Suggestions UI, configure Paperless 3.0.5 to use the suggestion bridge as described in [Paperless setup](docs/paperless-setup.md). The bridge must be bound to an address reachable by the Paperless container.
-
-For a longer walkthrough, use [Installation](docs/installation.md).
-
-## TrueNAS SCALE
-
-TrueNAS uses the same public GHCR images and the same four-service architecture; there is no TrueNAS fork.
-
-Use the dedicated [TrueNAS guide](docs/truenas.md) and the ready-to-edit YAML template in [`deploy/truenas/compose.example.yaml`](deploy/truenas/compose.example.yaml).
-
-For a Custom App that follows the floating `stable` image tag, TrueNAS can detect upstream image changes and present its normal **Update** action. No custom update script is required for code-only releases. Compose-structure changes are different and are called out in release notes.
-
-## Published images
-
-```text
-ghcr.io/lucaperl/paperless-local-ai-core:<tag>
-ghcr.io/lucaperl/paperless-local-ai-ocr:<tag>
-```
-
-Release tags:
-
-- `0.1.0`, `0.1.1`, ...: immutable-by-convention release tags for pinning;
-- `stable`: newest non-prerelease release, intended for update-aware installations;
-- `latest`: same non-prerelease release as `stable`.
-
-The GitHub release workflow builds both images from this repository and publishes build-provenance attestations.
-
-## Where configuration lives
-
-Settings have one owner instead of being duplicated across `.env`, JSON files and UI fields.
-
-| Owner | Examples |
-|---|---|
-| deployment `.env` / Compose | Paperless token, image tag, app-data path, host ports, resource limits |
-| **Studio -> App-Einstellungen** | Paperless/Ollama URL, workflow tags, OCR settings, polling, cleanup, dry-run |
-| **Studio -> Klassifizierung** | classification prompt + model/request parameters |
-| **Studio -> Korrespondent-Vorschlag** | fallback prompt + model/request parameters + enable switch |
-
-See [Configuration](docs/configuration.md).
-
-## Persistent data and backups
-
-All instance state lives below one `APP_DATA_DIR`:
-
-```text
-APP_DATA_DIR/
-├── config/        # app config + prompt configs + version history
-├── core/          # result JSON + open correspondent review records
-├── ocr/           # PaddleOCR model/cache/temp state
-└── coordination/  # shared ai.lock
-```
-
-The OCR model cache is regenerable. The important app-specific backup content is primarily `config/` plus any open review state in `core/`; Paperless remains the source of truth for document metadata and files.
-
-## Security and privacy
-
-- Never commit `.env` or a Paperless API token.
-- Prompt Studio has no authentication; bind it only to localhost or a trusted LAN.
-- The suggestion bridge should be reachable by Paperless, not by the public Internet.
-- There is no built-in telemetry or cloud inference endpoint.
-- Document text is sent to the **Ollama endpoint you configure**. Keep that endpoint local/self-hosted if local-only processing is a requirement.
-- PaddleOCR models may need network access on first use unless they are already cached.
-
-See [SECURITY.md](SECURITY.md).
-
-
-## Current limitations
-
-- Paperless native-suggestion compatibility is verified only for 3.0.5.
-- Published OCR image is currently linux/amd64 only.
-- Studio UI and shipped prompts are German in 0.1.0.
-- Ollama is the only inference backend in 0.1.0.
-- The app does not create required Paperless tags/workflows for you.
-- TrueNAS image updates cannot rewrite a Custom App's Compose YAML.
-
-## Development with Codex or other coding agents
-
-Start with [`AGENTS.md`](AGENTS.md). It records the project invariants that should not be accidentally broken: the four-service/two-image architecture, external Ollama, selective OCR policy, configuration ownership, shared AI lock and fail-closed correspondent matching.
-
-Local source build:
-
-```bash
-cp .env.example .env
-docker compose -f compose.yaml -f compose.dev.yaml up -d --build
-```
-
-Tests:
-
-```bash
-make test
-```
-
-See [Contributing](CONTRIBUTING.md), [Testing](docs/testing.md) and [Releasing](docs/releasing.md).
-
-## Documentation
-
-- [Installation](docs/installation.md)
+- [Docker Compose](docs/installation.md)
+- [TrueNAS SCALE](docs/truenas.md)
 - [Paperless setup](docs/paperless-setup.md)
-- [TrueNAS deployment](docs/truenas.md)
-- [Updating](docs/upgrading.md)
-- [Configuration ownership](docs/configuration.md)
-- [Architecture](docs/architecture.md)
-- [Prompt Studio](docs/prompt-studio.md)
-- [Compatibility](docs/compatibility.md)
-- [Troubleshooting](docs/troubleshooting.md)
-- [Testing](docs/testing.md)
-- [Releasing](docs/releasing.md)
 
-## License and project relationship
+More: [Configuration](docs/configuration.md) · [Troubleshooting](docs/troubleshooting.md) · [Architecture](docs/architecture.md)
 
-The project source in this repository is released under the [MIT License](LICENSE). Container images also contain third-party software under its own licenses. In particular, the OCR image directly uses PyMuPDF, whose upstream licensing is GNU AGPL v3 / commercial. Read [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md) before redistributing images or using the stack in a proprietary/commercial product.
+## Security
 
-Paperless-ngx, PaddleOCR/PaddlePaddle, PyMuPDF and Ollama are separate projects with their own licenses and trademarks. `paperless-local-ai` is an independent community project and is not affiliated with or endorsed by those projects.
+Prompt Studio has no built-in authentication. Keep it on localhost or a trusted network.
+
+## License
+
+MIT. Third-party components retain their own licenses; see [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,114 +1,89 @@
 # Architecture
 
-## Design goals
-
-1. Keep Paperless-ngx stock and updateable.
-2. Make expensive processing CPU-first and serialized for small homeservers.
-3. OCR only pages that need it.
-4. Keep metadata classification text-only.
-5. Never auto-create a genuinely new correspondent.
-6. Keep code in Git/images and user configuration in one persistent app directory.
-7. Give every setting one obvious owner.
+`paperless-local-ai` is intentionally narrow: improve scan OCR, classify metadata with a small local model, and keep uncertain new correspondents behind human review.
 
 ## Pipeline
 
 ```text
-Paperless-ngx
-   |
-   | workflow: add OCR queue tag
-   v
-ocr-worker ------------------------------+
-   |                                      |
-   | native / OCR_PAGE / VERIFY           | shared exclusive ai.lock
-   |                                      |
-   +--> update content if justified       |
-   +--> add LLM queue tag                 |
-                                          |
-metadata-worker --------------------------+
-   |
-   +--> main structured classification
-   |      title / type / correspondent / tags / created
-   |
-   +--> if correspondent == "" and fallback enabled:
-   |      second correspondent-only Ollama request
-   |
-   +--> existing exact name: apply
-   +--> new name: persist review candidate
-   v
-Paperless metadata + human review
-
-Paperless native AI-suggestions request
-   -> suggestion-bridge
-   -> uniquely match persistent review record
-   -> fetch classic /suggestions/ from Paperless
-   -> preserve classic suggestions
-   -> append only a still-open new correspondent candidate
-   -> return Ollama-compatible structured response
+Paperless workflow
+      ↓
+ocr-worker
+  native text → keep
+  scan/raster → PaddleOCR
+      ↓
+metadata-worker
+  one structured LLM request
+  title · type · tags · date · existing correspondent
+      ↓
+  no correspondent?
+      ↓
+optional correspondent-only request
+  existing → apply
+  new      → review candidate
+      ↓
+Paperless metadata + review
 ```
 
-## Containers
+The original PDF stored by Paperless is never replaced. The OCR worker updates Paperless' extracted content only when the page classification justifies it.
 
-The public app uses two images but four services:
+## Services
 
-- `paperless-local-ai-ocr`: PaddlePaddle + PaddleOCR + PyMuPDF + OCR worker.
-- `paperless-local-ai-core`: small Python image reused for metadata worker, Studio and suggestion bridge.
+One Compose project runs four long-lived services from two images:
 
-Ollama is external by design.
+| Service | Purpose |
+|---|---|
+| `ocr-worker` | page analysis and PaddleOCR |
+| `metadata-worker` | metadata classification and optional correspondent fallback |
+| `prompt-ui` | configuration, prompt editing and testing |
+| `suggestion-bridge` | Paperless native review adapter for new correspondent candidates |
 
-## Configuration ownership
+Ollama remains external.
 
-### Deployment configuration: `.env`
+Heavy OCR and LLM work share one exclusive `ai.lock` so they do not compete for the same low-power CPU at the same time.
 
-Only values that Docker must know before a process starts, plus secrets:
+## Design rationale
 
-- `PAPERLESS_TOKEN`
-- image prefix/version
-- `APP_DATA_DIR`
-- host bind addresses/ports
-- CPU, RAM and shared-memory limits
+### Why PaddleOCR?
 
-### Shared runtime configuration: `/config/app-config.json`
+Paperless/Tesseract remains useful for normal Paperless ingestion, but on the scans that motivated this project its text was often not clean enough as input for a small local LLM. Scan-like pages are therefore selectively reprocessed with PaddleOCR.
 
-Owned by **Studio -> App-Einstellungen**:
+Native digital PDF text is kept because OCRing already-good text adds CPU cost and can reduce quality.
 
-- Paperless URL
-- Ollama URL
-- OCR/LLM/review tag names
-- extra taxonomy-excluded tags
-- OCR language/version/device
-- worker poll interval
-- review cleanup interval
-- dry-run
+### Why one metadata request?
 
-Workers reload this configuration while running. No container restart is required for these values.
+The reference system is an Intel Core i3-8100 without a GPU. Repeating prompt processing for title, tags, type, date and correspondent made per-field LLM workflows too slow in practice.
 
-### Stage-specific configuration
+The main stage therefore returns all normal metadata in one structured request constrained by the current Paperless taxonomy.
 
-`prompt-config.json` and `correspondent-suggestion.json` intentionally remain separate because they are two independently testable/versioned LLM programs. Their model/request parameters live with their prompts in the same Studio section.
+### Why a separate correspondent fallback?
 
-### Internal constants
+The main request should stay constrained to existing values. Only when it cannot resolve a correspondent does a second, narrow prompt get permission to return a free-text name.
 
-Protocol/body/cache/safety constants that ordinary users should not tune are not exposed as fake settings. If a value has no supported operational use case, it stays code.
+An exact existing match can be applied. A genuinely new name becomes a review candidate and is never auto-created.
 
-## Persistent state
+### Why not just use Paperless native AI?
+
+Paperless native AI is a general suggestion feature. This project is built as an automatic queue-driven pipeline with selective OCR, constrained values and serialized resource-heavy work.
+
+### Why no chat, RAG or semantic search?
+
+They are useful features, but they are outside this project's goal. The target is reliable OCR plus automatic metadata classification on modest local hardware, without turning the app into a general document-AI platform.
+
+## Configuration and state
+
+Deployment owns secrets and Docker-level settings. Prompt Studio owns normal runtime settings and both LLM-stage configurations.
+
+Persistent state lives below one `APP_DATA_DIR`:
 
 ```text
-APP_DATA_DIR/
-├── config/       shared app + stage configs/history
-├── core/         results + correspondent review records
-├── ocr/          Paddle cache/temp state
-└── coordination/ shared ai.lock
+config/        app and prompt configuration/history
+core/          result and open review records
+ocr/           PaddleOCR cache/temp state
+coordination/  shared ai.lock
 ```
 
-## Failure behavior
+## Suggestion bridge identity
 
-- OCR processing error: OCR queue tag is removed and OCR error tag is set.
-- LLM processing error: LLM queue tag is removed and LLM error tag is set.
-- Bridge cannot uniquely map a Paperless request: no new correspondent suggestion is returned.
-- New correspondent: never created automatically.
+For Paperless-ngx 3.0.5, open correspondent review records are matched primarily by a SHA-256 signature of the normalized document content used by Paperless' no-RAG AI classifier. Ambiguous matches fail closed.
 
-### Suggestion identity
-
-The bridge uses review-record schema v4. Its primary identity is a SHA-256 signature of the normalized content that Paperless 3.0.5 feeds into the no-RAG AI classifier (`document.content[:4000]` before Paperless token-budget truncation). The old 96-word content signature remains only as a compatibility fallback for migrated v2/v3 records. If an old short-prefix collision occurs, the bridge compares the prompt-content signature against the current Paperless API content for each candidate; unresolved ambiguity fails closed.
-
-Filename matching is deliberately not used for identity. Paperless 3.0.5 places the model's internal `Document.filename` (current storage path) in its AI prompt, while the normal REST serializer exposes `original_file_name` and a generated `archived_file_name`, not that internal `filename` value. Treating those fields as equivalent would be unsafe.
+The legacy short-prefix signature remains only for migrated older records. Filename matching is deliberately not used because Paperless' internal model filename and normal REST filename fields are not equivalent.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,63 +1,29 @@
 # Compatibility
 
-Compatibility claims in this project are intentionally narrow. A feature is marked tested only after an integration test, not because it is expected to be similar.
+Compatibility claims are intentionally narrow: a combination is listed as tested only after an integration test.
 
-## Paperless-ngx
+| Component | Tested / supported in 0.1.0 |
+|---|---|
+| Paperless-ngx | **3.0.5** |
+| Deployment | Docker Compose v2 |
+| TrueNAS SCALE | **25.10.4** Custom App |
+| Platform | **linux/amd64** |
+| OCR reference | PP-OCRv6 · German · CPU |
+| Ollama reference model | **qwen3.5:4b** |
+| Documents | German end-to-end workflow |
 
-| Version | Status | Notes |
-|---|---|---|
-| 3.0.5 | **tested** | full OCR -> metadata -> review flow, REST metadata writes, classic suggestion preservation and native new-correspondent bridge tested end-to-end |
-| newer 3.x | unverified | OCR/REST portions may work, but native suggestion bridge compatibility is not assumed until tested |
-| 2.x | unsupported | the 0.1.0 native AI suggestion integration target is Paperless 3.0.5 |
+## Paperless versions
 
-The OCR and metadata workers use normal Paperless APIs and are less tightly coupled to a Paperless release than the suggestion bridge. The bridge parses the Paperless 3.0.5 no-RAG AI request shape and intentionally has a narrower compatibility claim.
+The OCR and metadata workers mostly use normal Paperless REST APIs and may work with newer releases.
 
-## Paperless REST API
+The native new-correspondent suggestion bridge is more version-sensitive because it depends on Paperless' AI suggestion request shape. Do not assume a newer Paperless release is compatible until it has been tested.
 
-The app uses token-authenticated REST requests for documents and taxonomy. Paperless server version changes should be treated independently from the native suggestion bridge contract; both need to be considered before expanding compatibility claims.
+Paperless 2.x is not a supported target for the 0.1.0 native suggestion integration.
 
-## Ollama
+## Other models and languages
 
-Ollama is external. The app uses Ollama's HTTP API for metadata inference and connection/model checks.
+Other installed Ollama models can be selected independently for the two LLM stages, but quality and performance are not assumed equivalent to the reference model.
 
-The shipped default stage model is:
-
-```text
-qwen3.5:4b
-```
-
-Another installed Ollama model can be selected separately for each LLM stage in Studio. Model quality/performance is not assumed equivalent.
-
-## Language
-
-Release 0.1.0 is production-tested with German documents:
-
-```text
-OCR language: de
-Default prompts: German
-Studio UI: German
-```
-
-PaddleOCR language is configurable and prompts are editable, but non-German end-to-end behavior is not yet listed as tested.
-
-## CPU architecture
-
-The published 0.1.0 OCR image is built/tested for:
-
-```text
-linux/amd64
-```
+OCR language and prompts are configurable. Non-German end-to-end behavior is not yet claimed as tested.
 
 ARM64 is not claimed in 0.1.0.
-
-## Deployment platforms
-
-- **Docker Compose v2**: canonical deployment definition.
-- **TrueNAS SCALE 25.10.4 Custom App**: production-tested reference deployment.
-- **Other Compose-capable platforms**: expected to be adaptable to the same images/service graph, but not individually certified by this project yet.
-
-## Native suggestion bridge identity
-
-The bridge is tested against the Paperless-ngx 3.0.5 no-RAG classification prompt. Review-record schema v4 signs normalized prompt content and uses the old short-prefix signature only as a compatibility fallback for migrated records. Ambiguity fails closed.
-
-If a future Paperless version changes the AI prompt/request contract, that version must be integration-tested before the bridge is marked compatible.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,66 +1,64 @@
-# Configuration ownership
+# Configuration
 
-`paperless-local-ai` intentionally has **three** configuration owners. A setting should exist in only one of them.
+Most day-to-day configuration is managed in **Prompt Studio**.
 
-## 1. Deployment: `.env`
+## App-Einstellungen
 
-Use `.env` only for values Docker needs before the application starts, plus secrets:
+### Connections
 
-```text
-PAPERLESS_TOKEN
-IMAGE_PREFIX
-APP_VERSION
-APP_DATA_DIR
-PROMPT_UI_BIND / PROMPT_UI_PORT
-SUGGESTION_BRIDGE_BIND / SUGGESTION_BRIDGE_PORT
-container CPU/RAM/shared-memory limits
-```
+- Paperless URL
+- Ollama URL
+- Paperless token presence check
 
-Changing Docker-owned values requires recreating/redeploying the affected container.
+The token itself remains a deployment secret and is never shown by the UI.
 
-The Paperless API token stays here because it is a secret. The Studio never returns its value.
+### Pipeline & tags
 
-## 2. Shared application runtime: App-Einstellungen
+- OCR queue/error tags
+- LLM queue/error tags
+- human-review tag
+- extra taxonomy-excluded tags
 
-Stored together in:
+### OCR
 
-```text
-APP_DATA_DIR/config/app-config.json
-```
+- language
+- PaddleOCR generation
+- device
 
-This owns:
+### Runtime
 
-```text
-Paperless URL
-Ollama URL
-OCR queue/error tag
-LLM queue/error tag
-review tag
-extra taxonomy-excluded tags
-OCR language/version/device
-poll interval
-review cleanup interval
-dry-run
-```
+- poll interval
+- review cleanup interval
+- dry-run
 
-Workers reload these settings while running.
+These settings are stored in `APP_DATA_DIR/config/app-config.json` and hot-reloaded by the workers.
 
-## 3. LLM-stage configuration
+## Klassifizierung
 
-The two LLM stages are deliberately independent programs and therefore keep separate versioned configs:
+Controls the main metadata request:
 
-```text
-Klassifizierung
-  prompt + model/request parameters
+- prompt
+- model and request parameters
+- context/output limits
+- prompt rendering and real model tests
+- version history
 
-Korrespondent-Vorschlag
-  prompt + model/request parameters + enabled switch
-```
+The response covers title, document type, tags, date and an existing correspondent in one structured request.
 
-This is intentional: restoring an old prompt must restore the model/context/output parameters that belonged to that prompt, without rolling back unrelated OCR or connection settings.
+## Korrespondent-Vorschlag
 
-## Not configurable on purpose
+Optional second stage used only when the main classifier cannot resolve a correspondent.
 
-Some implementation values are constants because exposing them would add unsupported tuning without a real operator use case. Examples include bridge request-body limit, taxonomy cache TTL and the review-signature word count.
+It has its own prompt, model settings, tests, history and production enable switch. New correspondents are never created automatically.
 
-If a value becomes operationally useful later, it should be promoted into the single appropriate owner instead of being added as another ad-hoc environment variable.
+## Deployment-only settings
+
+These remain outside Prompt Studio because Docker needs them before the app starts or because they are secrets:
+
+- `PAPERLESS_TOKEN`
+- image/version
+- `APP_DATA_DIR`
+- host bind addresses and ports
+- container CPU/RAM/shared-memory limits
+
+Changing deployment-owned values requires recreating or redeploying the affected containers.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,37 +1,20 @@
 # Installation
 
-This guide assumes you have never used `paperless-local-ai` before.
+This guide covers a normal Docker Compose deployment. For TrueNAS SCALE, use the [TrueNAS guide](truenas.md).
 
-The application is a **companion** to an existing Paperless-ngx and Ollama installation. It does not install either dependency.
+## Before you start
 
-## 1. Check the compatibility target
+You need:
 
-Release 0.1.0 is fully tested with:
+- a running Paperless-ngx instance;
+- a running Ollama instance reachable from the app containers;
+- Docker Compose v2;
+- a Paperless API token;
+- an installed Ollama model (`qwen3.5:4b` is the default).
 
-```text
-Paperless-ngx: 3.0.5
-Platform:      linux/amd64
-Inference:     external Ollama
-OCR:           CPU PaddleOCR / PP-OCRv6
-```
+Release 0.1.0 is tested on linux/amd64 with Paperless-ngx 3.0.5. See [Compatibility](compatibility.md).
 
-Read [compatibility.md](compatibility.md) before using another Paperless version.
-
-The Studio UI and the default prompts are German in 0.1.0. OCR language itself is configurable.
-
-## 2. Make the default Ollama model available
-
-The shipped prompt configurations use:
-
-```text
-qwen3.5:4b
-```
-
-Make sure that model is installed on the Ollama server, or select another installed model later in the Studio.
-
-Ollama must be reachable **from the paperless-local-ai containers**. If Ollama runs on the Docker host, do not enter `localhost` unless the networking setup specifically makes the host available there; container localhost normally points back to that container.
-
-## 3. Get the repository deployment files
+## 1. Download
 
 ```bash
 git clone https://github.com/lucaperl/paperless-local-ai.git
@@ -39,26 +22,9 @@ cd paperless-local-ai
 cp .env.example .env
 ```
 
-Alternatively, download a GitHub release/source archive and extract it.
+## 2. Configure deployment values
 
-## 4. Create a Paperless API token
-
-In Paperless:
-
-1. open the user menu;
-2. open **My Profile**;
-3. create/regenerate the API token;
-4. copy it into `.env` as `PAPERLESS_TOKEN`.
-
-Paperless token authentication is the normal REST API mechanism used by the app. The token belongs to a Paperless user, so that user must be allowed to read and update the documents/taxonomy the app should manage.
-
-Never commit `.env`.
-
-## 5. Configure deployment-only values
-
-Edit `.env`.
-
-Required/recommended review:
+Edit `.env` and review at least:
 
 ```text
 PAPERLESS_TOKEN
@@ -66,202 +32,54 @@ APP_VERSION
 APP_DATA_DIR
 PROMPT_UI_BIND / PROMPT_UI_PORT
 SUGGESTION_BRIDGE_BIND / SUGGESTION_BRIDGE_PORT
-resource limits
 ```
 
-The default image prefix already points to the upstream project:
+Use `APP_VERSION=stable` to follow the newest non-prerelease image, or pin an exact release such as `0.1.0`.
 
-```text
-ghcr.io/lucaperl/paperless-local-ai
-```
+Normal runtime settings such as Paperless/Ollama URLs, OCR language, workflow tags and prompts are configured in Prompt Studio, not duplicated in `.env`.
 
-Use:
-
-```text
-APP_VERSION=stable
-```
-
-to follow the newest non-prerelease image, or:
-
-```text
-APP_VERSION=0.1.0
-```
-
-to pin the first release.
-
-Do **not** put Paperless/Ollama URLs, OCR language or workflow-tag names in `.env`; those are runtime settings owned by the Studio.
-
-## 6. Start only Prompt Studio
+## 3. Start Prompt Studio
 
 ```bash
 docker compose up -d prompt-ui
 ```
 
-Default URL on the Docker host:
+Default local URL:
 
 ```text
 http://127.0.0.1:30148/
 ```
 
-To open Studio from another trusted LAN machine, change `PROMPT_UI_BIND` from `127.0.0.1` to the host's LAN address and recreate the service:
+Prompt Studio has no built-in authentication. Only bind it to localhost or a trusted network.
 
-```bash
-docker compose up -d --force-recreate prompt-ui
-```
+In **App-Einstellungen**, configure and test the Paperless and Ollama connections, then review tags, OCR and runtime settings.
 
-Do not expose Studio directly to the Internet; it has no built-in authentication.
+Container networking matters: `localhost` inside a container is not the Docker host. Use addresses the containers can actually reach.
 
-## 7. Configure App-Einstellungen
+## 4. Configure Paperless
 
-Open **App-Einstellungen** in Studio and set:
+Create the required technical tags and import workflow from [Paperless setup](paperless-setup.md).
 
-### Connections
+## 5. Review the LLM stages
 
-- Paperless URL, for example `http://192.0.2.10:8000`;
-- Ollama URL, for example `http://192.0.2.20:11434`.
+In Prompt Studio:
 
-Use addresses that are routable **from inside the containers**.
+- **Klassifizierung** controls the main structured metadata request;
+- **Korrespondent-Vorschlag** controls the optional second pass used only when the main classifier cannot resolve a correspondent.
 
-Run the connection test before saving.
+Test both stages with known documents before enabling the correspondent fallback for production use.
 
-### Pipeline & tags
-
-Choose names for:
-
-- OCR queue tag;
-- OCR error tag;
-- LLM queue tag;
-- LLM error tag;
-- human-review tag;
-- optional taxonomy-excluded tags.
-
-The defaults are documented in [paperless-setup.md](paperless-setup.md).
-
-### OCR
-
-Choose PaddleOCR language/version/device. Release 0.1.0 is tested with:
-
-```text
-PP-OCRv6 / de / cpu
-```
-
-### Runtime
-
-The shipped defaults are:
-
-```text
-polling:        10 seconds
-review cleanup: 3600 seconds
-dry-run:        false
-```
-
-Workers hot-reload App-Einstellungen while running.
-
-## 8. Create the required Paperless tags and workflow
-
-Follow [paperless-setup.md](paperless-setup.md).
-
-The app intentionally does not create or rename Paperless taxonomy objects automatically.
-
-## 9. Review the LLM configurations
-
-Studio has two independent LLM stages:
-
-### Klassifizierung
-
-Main structured metadata classification.
-
-Review the prompt and model settings, then use **Mit Modell testen** on a known document before production processing.
-
-### Korrespondent-Vorschlag
-
-Optional second model pass used only when the main classifier returns no correspondent.
-
-A fresh installation starts this fallback **disabled**. Test it manually, then enable **Produktiv verwenden** if the results are acceptable.
-
-## 10. Start all runtime services
+## 6. Start and verify
 
 ```bash
 docker compose up -d
-```
-
-Check:
-
-```bash
-docker compose ps
-```
-
-Expected long-lived services:
-
-```text
-ocr-worker
-metadata-worker
-prompt-ui
-suggestion-bridge
-```
-
-## 11. Run the doctor
-
-```bash
 docker compose --profile tools run --rm doctor
 ```
 
-The doctor checks:
+The doctor checks Paperless, the token, required tags, Ollama and configured models.
 
-- App-Einstellungen are readable;
-- Paperless is reachable and the token works;
-- required Paperless tags exist;
-- Ollama is reachable;
-- configured model names exist in Ollama.
+Import one normal test document before processing a larger batch.
 
-Fix every `FAIL` before processing real documents.
+## First OCR run
 
-## 12. Process one test document
-
-Import one ordinary document through the normal Paperless consume/import path.
-
-Watch:
-
-```bash
-docker compose logs -f ocr-worker metadata-worker
-```
-
-Confirm the expected flow:
-
-```text
-OCR queue -> selective OCR -> LLM queue -> metadata write -> review
-```
-
-Do not bulk-reprocess an archive until the one-document test is correct.
-
-## 13. Optional native correspondent Suggestions integration
-
-This is not required for OCR or main metadata classification.
-
-If you want genuinely new correspondent names to appear in Paperless' native Suggestions UI:
-
-1. bind `SUGGESTION_BRIDGE_BIND` to an address Paperless can reach;
-2. recreate `suggestion-bridge` if the deployment setting changed;
-3. configure Paperless 3.0.5 AI settings exactly as described in [paperless-setup.md](paperless-setup.md);
-4. verify `http://<bridge-host>:30149/health` from a network location equivalent to Paperless.
-
-The bridge deliberately does not auto-create a correspondent.
-
-## 14. First OCR model download
-
-The OCR image contains the Paddle software stack, but PaddleX/PaddleOCR model assets are cached under:
-
-```text
-APP_DATA_DIR/ocr/.paddlex
-```
-
-The first OCR use can therefore require network access and take longer while model files are downloaded. Later runs reuse the persistent cache.
-
-## Next steps
-
-- [Configuration ownership](configuration.md)
-- [Architecture](architecture.md)
-- [Prompt Studio](prompt-studio.md)
-- [TrueNAS](truenas.md)
-- [Updating](upgrading.md)
-- [Troubleshooting](troubleshooting.md)
+PaddleOCR model assets are cached below `APP_DATA_DIR/ocr/`. The first OCR run may take longer while missing model files are downloaded.

--- a/docs/paperless-setup.md
+++ b/docs/paperless-setup.md
@@ -1,49 +1,34 @@
 # Paperless-ngx setup
 
-This document describes the Paperless-side configuration expected by `paperless-local-ai` 0.1.0.
+`paperless-local-ai` needs five technical/review tags and one import workflow.
 
-The native new-correspondent bridge is verified specifically with **Paperless-ngx 3.0.5**.
+## API token
 
-## 1. API token
+Create a Paperless API token under **My Profile** and provide it to the deployment as `PAPERLESS_TOKEN`.
 
-`paperless-local-ai` uses Paperless' normal REST API with token authentication.
+The token's Paperless user must be allowed to read and update the documents and taxonomy the app should manage.
 
-In Paperless open **My Profile** and create/regenerate an API token. Put the value only in the deployment `.env`/secret environment as `PAPERLESS_TOKEN`.
+## Tags
 
-Use a token belonging to a Paperless user that may read/update the documents and taxonomy this app should manage.
+Fresh-install defaults are:
 
-## 2. Required technical tags
-
-Fresh-install defaults from **Studio -> App-Einstellungen -> Pipeline & Tags** are:
-
-```text
-PaddleOCR
-PaddleOCR Fehler
-LLM
-LLM Fehler
-Inbox
-```
+| Tag | Purpose |
+|---|---|
+| `PaddleOCR` | OCR queue |
+| `PaddleOCR Fehler` | OCR errors |
+| `LLM` | metadata queue |
+| `LLM Fehler` | metadata errors |
+| `Inbox` | human review |
 
 `TODO` is the default additional tag excluded from normal LLM content-tag candidates.
 
-You may rename all technical tags. The names configured in Paperless and Studio must match exactly.
+You may rename the tags in Prompt Studio. Paperless and Studio names must match exactly.
 
-Set the matching algorithm of the four queue/error tags to **None** so Paperless' automatic matching does not assign them independently:
+Set automatic matching to **None** for the four queue/error tags so Paperless does not assign them independently.
 
-```text
-PaddleOCR
-PaddleOCR Fehler
-LLM
-LLM Fehler
-```
+## Import workflow
 
-The review tag (`Inbox` by default) can follow your normal Paperless review workflow.
-
-## 3. Import workflow
-
-Create a Paperless workflow that queues newly added documents for the OCR stage.
-
-Example:
+Create a workflow such as:
 
 ```text
 Name:    PaddleOCR Queue
@@ -51,57 +36,38 @@ Trigger: Document added
 Action:  add tag PaddleOCR
 ```
 
-If you renamed the OCR queue tag in Studio, use that name instead.
-
-The runtime then owns the technical handoff:
+The app then owns the handoff:
 
 ```text
-Paperless workflow
-  -> OCR queue tag
-  -> ocr-worker
-  -> LLM queue tag
-  -> metadata-worker
-  -> human review tag remains
+PaddleOCR → ocr-worker → LLM → metadata-worker → Inbox/review
 ```
 
-On a real OCR error the OCR queue tag is removed and the configured OCR error tag is set. The LLM worker follows the equivalent behavior for its queue/error tags.
+On processing errors, the active queue tag is removed and the configured error tag is applied.
 
-## 4. Taxonomy behavior
+## Taxonomy behavior
 
-The main classification stage does not invent arbitrary document types, normal correspondents or content tags. Allowed values are loaded from the current Paperless taxonomy for each job.
+The main classifier is constrained to the current Paperless document types, normal correspondents and content tags.
 
-The separate correspondent fallback is the only stage that can return a free-text correspondent name:
+If the optional correspondent fallback finds an exact existing correspondent, it can be applied automatically. A genuinely new name is stored only as a review candidate and is never auto-created.
 
-- exact normalized match to an existing Paperless correspondent -> apply it;
-- genuinely new name -> save a review candidate;
-- never automatically create a new correspondent.
+## Optional: native new-correspondent review
 
-## 5. Optional native new-correspondent review
+This integration is only needed if new correspondent candidates should appear in Paperless' native Suggestions UI.
 
-This feature is **not required** for selective OCR or normal metadata classification.
+Paperless must be able to reach the suggestion bridge. For the default host port:
 
-Enable it only if a new correspondent candidate should appear in Paperless' native Suggestions UI.
+```text
+http://<bridge-host>:30149
+```
 
-### What the bridge replaces
-
-Paperless 3.0.5 is configured to use `suggestion-bridge` as its Ollama-compatible AI suggestion backend. The bridge itself performs **no LLM inference**. It preserves classic Paperless suggestions and adds only a uniquely matched, still-open correspondent review candidate.
-
-Because this occupies Paperless' AI-suggestions backend, it does not proxy or chain to a second Paperless LLM backend.
-
-### Network requirement
-
-Paperless must be able to reach the bridge URL. If Paperless runs in a container, a bridge bound only to host `127.0.0.1` is normally **not** reachable from that Paperless container. Bind the bridge to a trusted host/LAN address and do not expose it publicly.
-
-### Tested Paperless 3.0.5 AI settings
-
-In **Application Configuration -> AI**, configure the equivalent of:
+For the tested Paperless-ngx 3.0.5 setup, configure **Application Configuration → AI** as follows:
 
 ```text
 Enable AI features:        on
 LLM backend:               ollama
 LLM model:                 paperless-correspondent-bridge
 LLM endpoint:              http://<bridge-host>:30149
-Allow internal endpoints:  on   (required when the bridge is on a private/LAN address)
+Allow internal endpoints:  on   # when using a private/LAN address
 LLM embedding backend:     none / empty
 LLM embedding model:       empty
 LLM embedding endpoint:    empty
@@ -111,26 +77,6 @@ LLM output language:       empty
 LLM API key:               empty
 ```
 
-Do not enable an embedding backend for this bridge integration; the tested request identity is the Paperless 3.0.5 no-RAG suggestion shape.
+The bridge does not run another LLM. It preserves Paperless' classic suggestions and adds only a uniquely matched, still-open correspondent candidate.
 
-### Health check
-
-The bridge exposes:
-
-```text
-GET /health
-```
-
-For a default host port:
-
-```text
-http://<bridge-host>:30149/health
-```
-
-A healthy bridge still returns no new correspondent if request identity is missing/ambiguous or the review record is no longer open. That fail-closed behavior is intentional.
-
-## 6. Paperless version changes
-
-The OCR and metadata workers mostly use normal REST API behavior. The native suggestion bridge is more tightly coupled to Paperless' AI prompt/request contract.
-
-Before upgrading Paperless beyond a version marked tested in [compatibility.md](compatibility.md), either disable the native bridge integration or validate it against the new Paperless release first.
+The bridge is version-sensitive. Check [Compatibility](compatibility.md) before upgrading Paperless.

--- a/docs/prompt-studio.md
+++ b/docs/prompt-studio.md
@@ -1,45 +1,21 @@
-# paperless-local-ai Studio
+# Prompt Studio
 
-The Studio is the central application UI. It has three clearly separated owners instead of one mixed settings page.
+Prompt Studio is the web UI for normal `paperless-local-ai` operation. It keeps runtime settings, prompt configuration and testing in one place.
 
 ## App-Einstellungen
 
-Shared runtime configuration for the whole application:
+Configure Paperless/Ollama connections, workflow tags, OCR settings, polling, review cleanup and dry-run.
 
-- **Verbindungen**: Paperless URL, Ollama URL and a safe token-presence indicator; includes a draft connection test.
-- **Pipeline & Tags**: OCR queue/error, LLM queue/error, review tag and additional taxonomy-excluded tags.
-- **OCR**: language, PaddleOCR generation and device.
-- **Betrieb**: polling interval, review cleanup and dry-run.
-- **Verlauf**: versioned app configuration and restore-as-new-version.
-
-Saved values are written to `app-config.json` and are reloaded by workers while running.
-
-The Paperless API token is deliberately not editable here. It is a secret and remains in deployment configuration (`.env` or a future Docker Secret).
+Saved values are hot-reloaded by the workers. The Paperless API token is intentionally not editable here; it remains a deployment secret.
 
 ## Klassifizierung
 
-- **Prompt**: system prompt and classification template.
-- **Test**: render the final prompt without inference, or run a real Ollama test without writing Paperless metadata.
-- **Ausgabe & erlaubte Werte**: structured output contract and current Paperless taxonomy.
-- **Einstellungen**: model/context/output/token/text-window parameters specific to stage 1.
-- **Verlauf**: version history and restore-as-new-version.
+Edit and test the main structured metadata prompt and its model/request parameters. A model test does not write metadata back to Paperless.
 
 ## Korrespondent-Vorschlag
 
-- **Prompt**: independent correspondent-only prompt.
-- **Test**: isolated real model test; no Paperless write and no persistent review candidate.
-- **Einstellungen**: model/request parameters specific to stage 2 and `Produktiv verwenden`.
-- **Verlauf**: independent version history.
+Configure the optional correspondent-only fallback. It runs only when the main classifier cannot resolve a correspondent and must be explicitly enabled for production use.
 
-A fresh install starts the correspondent fallback disabled. Enable it only after document-ID tests look correct.
+Each section keeps its own version history so prompt/model changes can be restored safely.
 
-## Why model settings are not in App-Einstellungen
-
-This is intentional rather than accidental duplication. Classification and correspondent fallback are independent LLM stages with different context/output needs. A saved version must keep each prompt together with the exact model parameters used to run that prompt.
-
-## Save semantics
-
-- `Konfiguration prüfen`: validate current draft only.
-- `Änderungen speichern`: create a new active version.
-- `Finalen Prompt anzeigen`: render only; no model call.
-- `Mit Modell testen`: real Ollama request under the shared AI lock; no document metadata write.
+See [Configuration](configuration.md) for setting ownership and [Paperless setup](paperless-setup.md) for the required Paperless-side workflow.

--- a/docs/truenas.md
+++ b/docs/truenas.md
@@ -1,18 +1,14 @@
-# TrueNAS SCALE deployment
+# TrueNAS SCALE
 
-`paperless-local-ai` runs on TrueNAS as a **Custom App installed from Docker Compose YAML**. TrueNAS is only a deployment target: it uses the exact same GHCR images as a normal Docker installation.
+`paperless-local-ai` runs as a TrueNAS **Custom App installed from Docker Compose YAML**. It uses the same public GHCR images as a normal Docker deployment.
 
-The production-tested reference is **TrueNAS SCALE 25.10.4**.
+Tested reference: **TrueNAS SCALE 25.10.4**.
 
-## What you need before installing
+## Before you start
 
-- working Paperless-ngx and Ollama apps/services;
-- a persistent dataset for `paperless-local-ai`;
-- a Paperless API token;
-- ports for Studio and the optional suggestion bridge;
-- Paperless/Ollama addresses reachable from the Custom App containers.
+You need working Paperless-ngx and Ollama services, a persistent dataset and a Paperless API token.
 
-## 1. Create one dataset
+## 1. Create the app dataset
 
 Example:
 
@@ -20,75 +16,45 @@ Example:
 /mnt/POOL/paperless-local-ai
 ```
 
-The app will use:
-
-```text
-config/
-core/
-ocr/
-coordination/
-```
-
-Do not place source code in this dataset. Source code lives in the GHCR images.
-
-## 2. Store the Paperless token
-
-Recommended approach: create a root-readable deployment environment file containing only the secret:
+Create a token file:
 
 ```text
 /mnt/POOL/paperless-local-ai/paperless.env
 ```
 
-Contents:
+with:
 
 ```text
 PAPERLESS_TOKEN=your-token-here
 ```
 
-Restrict it to root where practical (for example mode `600`).
+Restrict the file to root where practical, for example mode `600`.
 
-If you prefer to manage the token directly in the Custom App YAML, you can replace the `env_file` entries in the template with an `environment: PAPERLESS_TOKEN: ...` value, but remember that the token will then be visible in the stored YAML/UI.
+## 2. Prepare the YAML
 
-## 3. Edit the TrueNAS Compose template
-
-Copy [`../deploy/truenas/compose.example.yaml`](../deploy/truenas/compose.example.yaml) into a text editor and replace every occurrence of:
+Copy [`deploy/truenas/compose.example.yaml`](../deploy/truenas/compose.example.yaml) and replace every occurrence of:
 
 ```text
 /mnt/YOUR_POOL/paperless-local-ai
 ```
 
-with your real dataset path.
+with your dataset path.
 
-The template uses:
+The template uses the public `stable` images and exposes Prompt Studio on port `30148` and the suggestion bridge on `30149`.
 
-```text
-ghcr.io/lucaperl/paperless-local-ai-core:stable
-ghcr.io/lucaperl/paperless-local-ai-ocr:stable
-```
+The included CPU/RAM values are conservative container limits, not measured minimum requirements.
 
-and exposes:
-
-```text
-30148 -> Prompt Studio
-30149 -> suggestion bridge
-```
-
-The template binds both ports to `0.0.0.0` so they are reachable on the TrueNAS LAN address. Prompt Studio has no authentication: only use this on a trusted network, or change the bind address to a specific trusted TrueNAS IP.
-
-## 4. Install the Custom App
+## 3. Install the Custom App
 
 In TrueNAS:
 
 1. open **Apps**;
-2. open **Discover Apps**;
-3. choose the Custom App / **Install via YAML** option;
-4. name the app `paperless-local-ai`;
-5. paste the edited YAML;
-6. install it.
+2. choose the Custom App / **Install via YAML** option;
+3. name the app `paperless-local-ai`;
+4. paste the edited YAML;
+5. install it.
 
-No private TrueNAS-specific image is required.
-
-## 5. Configure runtime settings in Studio
+## 4. Configure through Prompt Studio
 
 Open:
 
@@ -96,99 +62,14 @@ Open:
 http://<truenas-ip>:30148/
 ```
 
-Under **App-Einstellungen** configure:
+Configure Paperless/Ollama connections, tags, OCR and runtime settings in the UI, then follow [Paperless setup](paperless-setup.md).
 
-```text
-Paperless URL: http://<truenas-or-paperless-host>:<paperless-port>
-Ollama URL:    http://<truenas-or-ollama-host>:<ollama-port>
-```
+Prompt Studio has no built-in authentication. Keep it on a trusted network or bind it to a specific trusted address.
 
-Then configure tags/OCR/runtime settings and save.
+## Updates
 
-Do not duplicate these values in the Custom App YAML. They are persistent AppConfig state and are hot-reloaded by the workers.
+The supplied YAML follows the floating `stable` GHCR tag. With Docker image update checks enabled, TrueNAS can present its normal **Update** action when a new image digest is published.
 
-## 6. Prepare Paperless
+If release notes mention a Compose change, update the stored Custom App YAML as part of that release. Image updates alone cannot rewrite the YAML.
 
-Follow [paperless-setup.md](paperless-setup.md):
-
-- create queue/error/review tags;
-- create the import workflow;
-- optionally configure Paperless 3.0.5 AI Suggestions to use the bridge.
-
-For native review, Paperless must be able to reach:
-
-```text
-http://<truenas-ip>:30149
-```
-
-## 7. Resource defaults
-
-The template matches the production-tested low-power deployment:
-
-```text
-ocr-worker:        2 CPU / 6 GiB RAM / 2 GiB shm
-metadata-worker:   0.5 CPU / 512 MiB RAM
-prompt-ui:          0.25 CPU / 256 MiB RAM
-suggestion-bridge:  0.1 CPU / 128 MiB RAM
-```
-
-Adjust Docker-owned limits in the YAML if your system requires different values.
-
-## 8. Normal updates — no shell script
-
-Keep the two images on the floating non-prerelease tag:
-
-```text
-stable
-```
-
-In **Apps -> Settings**, leave **Check for docker image updates** enabled.
-
-TrueNAS monitors images used by Custom Apps. When the upstream digest behind `stable` changes, TrueNAS can show its normal **Update** action for the Custom App. Apply the update from the TrueNAS UI.
-
-You do **not** need a custom updater script for ordinary code/UI/worker releases.
-
-### Exact-version alternative
-
-If you prefer a fully pinned deployment, replace `stable` in both image names with a release such as:
-
-```text
-0.1.0
-```
-
-TrueNAS will then stay on that image tag until you edit the YAML or deliberately move to another version.
-
-## 9. Important Custom App limitation
-
-An image update changes container images; it does **not** rewrite the Custom App's stored Compose YAML.
-
-If a future release changes any of these deployment contracts:
-
-- service graph;
-- commands;
-- mounts;
-- ports;
-- required deployment environment;
-- resource-related Compose fields;
-
-review the release notes and update the YAML as part of that upgrade.
-
-Code-only releases do not require that extra step.
-
-## 10. First real document
-
-After the app is healthy:
-
-1. verify Studio connections;
-2. verify Paperless technical tags/workflow;
-3. import one normal document;
-4. confirm OCR -> LLM -> review;
-5. only then process larger batches.
-
-## Reference files
-
-- [`deploy/truenas/compose.example.yaml`](../deploy/truenas/compose.example.yaml)
-- [Installation](installation.md)
-- [Paperless setup](paperless-setup.md)
-- [Updating](upgrading.md)
-- [Troubleshooting](troubleshooting.md)
+For fully pinned deployments, replace `stable` in both image names with an exact release such as `0.1.0`.


### PR DESCRIPTION
## Summary

- streamline the README around the actual user workflow
- clarify the CPU-first design and one-call metadata classification
- document the optional correspondent fallback and Paperless review flow
- make Prompt Studio more prominent
- add reference hardware and real-world timings
- simplify installation, TrueNAS, configuration and compatibility docs
- remove the misleading 6 GiB OCR requirement