### PR TITLE
Add manual test image workflow

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -1,0 +1,110 @@
+name: Build test images
+
+run-name: Test images for ${{ inputs.ref }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build (branch, tag, or full commit SHA)"
+        required: true
+        default: "main"
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  resolve:
+    name: Resolve test ref
+    runs-on: ubuntu-latest
+
+    outputs:
+      sha: ${{ steps.ref.outputs.sha }}
+      short_sha: ${{ steps.ref.outputs.short_sha }}
+      image_tag: ${{ steps.ref.outputs.image_tag }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 1
+
+      - name: Resolve commit
+        id: ref
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          sha="$(git rev-parse HEAD)"
+          short_sha="$(git rev-parse --short=12 HEAD)"
+          image_tag="test-${short_sha}"
+
+          {
+            echo "sha=${sha}"
+            echo "short_sha=${short_sha}"
+            echo "image_tag=${image_tag}"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Resolved ${{ inputs.ref }} to ${sha}"
+          echo "Image tag: ${image_tag}"
+
+  build:
+    name: Build ${{ matrix.component }}
+    needs: resolve
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - component: core
+            dockerfile: docker/core.Dockerfile
+          - component: ocr
+            dockerfile: docker/ocr.Dockerfile
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+          fetch-depth: 1
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push test image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/paperless-local-ai-${{ matrix.component }}:${{ needs.resolve.outputs.image_tag }}
+          labels: |
+            org.opencontainers.image.title=paperless-local-ai ${{ matrix.component }} test image
+            org.opencontainers.image.description=Commit-pinned test image for paperless-local-ai
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ needs.resolve.outputs.sha }}
+            org.opencontainers.image.version=${{ needs.resolve.outputs.image_tag }}
+          build-args: |
+            APP_VERSION=dev
+            SOURCE_URL=https://github.com/${{ github.repository }}
+
+      - name: Show test image
+        shell: bash
+        run: |
+          {
+            echo "### ${{ matrix.component }}"
+            echo
+            echo '```text'
+            echo "ghcr.io/${{ github.repository_owner }}/paperless-local-ai-${{ matrix.component }}:${{ needs.resolve.outputs.image_tag }}"
+            echo '```'
+            echo
+            echo "Commit: \`${{ needs.resolve.outputs.sha }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Adds a manual GitHub Actions workflow for building deployable test images without creating a release.

## Behavior

- runs only when manually triggered
- accepts a branch, tag, or exact commit SHA
- resolves the selected ref to an exact commit before building
- builds both core and OCR images
- publishes immutable `test-<sha>` tags to GHCR
- records the exact source commit in the OCI image metadata
- never updates `stable`, `latest`, or release version tags

This provides a reproducible way to test exact commits on TrueNAS before creating a release while leaving production image tags untouched.