### PR TITLE
Fix Paperless UI readiness detection

### DIFF
--- a/SOURCE-MANIFEST.json
+++ b/SOURCE-MANIFEST.json
@@ -46,8 +46,9 @@
     "src/ocr/ocrmypdf_plai.py": "9a02361f15f931484fa20d96b958336cef155f6c74bd4384c361828faa569b57",
     "src/ocr/paddle_engine.py": "5829a8eafbcf28772ddaedfef11f249eaef62a717bf7121cb09b850b5caed435",
     "src/ocr/paperless_local_ai_ui/__init__.py": "af38528d3d4e1efa14f975a3a7f2c34ca28aacebe87167605740f002443d360d",
-    "src/ocr/paperless_local_ai_ui/apps.py": "2e55de5b54c17a6c20c54611bf8346de97db69cf1b5a91ef77143c5e72512789",
-    "src/ocr/paperless_local_ai_ui/injection.py": "c79a0205b20d9f36aee0c7694bc9894e880c3d4a38e15319baabf19757874a2f",
+    "src/ocr/paperless_local_ai_ui/apps.py": "d8741137876a4fd856f971adb2d67024b47f85f2e665f2b0e52aa484265e7df9",
+    "src/ocr/paperless_local_ai_ui/injection.py": "6cb961bccd5e6fa1b7497779149f9ed553455bde5748866aaf5710dc0ee77ac1",
+    "src/ocr/paperless_local_ai_ui/middleware.py": "ca9ad5d6e6dab52cad3f626990a3a3ba897f611f4e0a565eb97d1f638f2d7d21",
     "src/ocr/service.py": "1334a5b8a175e8a168c0c0b32cf3be1a95e752e5e62865c04922a7cf6f1a361e"
   }
 }

--- a/src/ocr/paperless_local_ai_ui/apps.py
+++ b/src/ocr/paperless_local_ai_ui/apps.py
@@ -1,31 +1,10 @@
 from __future__ import annotations
 
-import logging
-
 from django.apps import AppConfig
-from django.core.signals import request_started
+from django.conf import settings
 
 
-LOG = logging.getLogger("paperless_local_ai_ui")
-_ATTACH_UID = "paperless_local_ai_ui.attach_index_view"
-
-
-def _attach_to_index_view(**_kwargs) -> None:
-    # Delay importing Paperless views until an actual HTTP request arrives.
-    # Celery/background processes load the tiny Django app but never pull in
-    # the web view solely for this optional integration.
-    request_started.disconnect(_attach_to_index_view, dispatch_uid=_ATTACH_UID)
-    try:
-        from documents.views import IndexView
-
-        from .injection import patch_index_view
-
-        patch_index_view(IndexView)
-    except Exception:
-        LOG.exception(
-            "paperless-local-ai UI integration could not attach; "
-            "Paperless will continue without the shortcut"
-        )
+_MIDDLEWARE = "paperless_local_ai_ui.middleware.PaperlessLocalAiUiMiddleware"
 
 
 class PaperlessLocalAiUiConfig(AppConfig):
@@ -33,8 +12,8 @@ class PaperlessLocalAiUiConfig(AppConfig):
     verbose_name = "paperless-local-ai UI integration"
 
     def ready(self) -> None:
-        request_started.connect(
-            _attach_to_index_view,
-            weak=False,
-            dispatch_uid=_ATTACH_UID,
-        )
+        # Register the integration as the outermost Django middleware. The
+        # middleware itself is only instantiated by the web handler, so Celery
+        # and other background processes do not import Paperless web views.
+        if _MIDDLEWARE not in settings.MIDDLEWARE:
+            settings.MIDDLEWARE = [_MIDDLEWARE, *settings.MIDDLEWARE]

--- a/src/ocr/paperless_local_ai_ui/injection.py
+++ b/src/ocr/paperless_local_ai_ui/injection.py
@@ -113,10 +113,6 @@ def inject_response(response):
         if "text/html" not in response.get("Content-Type", ""):
             return response
 
-        # Present whenever Paperless has successfully loaded this Django
-        # integration, even while the optional shortcut itself is disabled.
-        response["X-Paperless-Local-AI-UI"] = "ready"
-
         control_center_url = _control_center_url()
         if control_center_url is None:
             return response

--- a/src/ocr/paperless_local_ai_ui/middleware.py
+++ b/src/ocr/paperless_local_ai_ui/middleware.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+
+LOG = logging.getLogger("paperless_local_ai_ui")
+READY_HEADER = "X-Paperless-Local-AI-UI"
+
+
+class PaperlessLocalAiUiMiddleware:
+    # Attach the Paperless UI hook and expose functional readiness.
+
+    def __init__(self, get_response: Callable[[Any], Any]) -> None:
+        self.get_response = get_response
+        self.ready = False
+        try:
+            from documents.views import IndexView
+
+            from .injection import patch_index_view
+
+            patch_index_view(IndexView)
+            self.ready = True
+        except Exception:
+            LOG.exception(
+                "paperless-local-ai UI integration could not attach; "
+                "Paperless will continue without the shortcut"
+            )
+
+    def __call__(self, request: Any) -> Any:
+        response = self.get_response(request)
+        if self.ready:
+            # The marker is intentionally independent of shortcut enabled state.
+            # Being outermost also makes it visible on login redirects, allowing
+            # an unauthenticated Control Center readiness probe to verify that
+            # Paperless actually loaded and attached the integration.
+            response[READY_HEADER] = "ready"
+        return response

--- a/tests/test_paperless_ui_integration.py
+++ b/tests/test_paperless_ui_integration.py
@@ -4,6 +4,7 @@ import importlib
 import json
 import sys
 from pathlib import Path
+from types import ModuleType
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -51,7 +52,6 @@ def test_disabled_is_noop(tmp_path, monkeypatch):
     response = Response()
     original = response.content
     assert module.inject_response(response).content == original
-    assert response.headers["X-Paperless-Local-AI-UI"] == "ready"
 
 
 def test_enabled_injects_settings_link_script(tmp_path, monkeypatch):
@@ -67,7 +67,6 @@ def test_enabled_injects_settings_link_script(tmp_path, monkeypatch):
     assert 'document.createTextNode("paperless-local-ai")' in text
     assert "https://plai.example/" in text
     assert 'href === "admin/"' in text
-    assert response.headers["X-Paperless-Local-AI-UI"] == "ready"
     assert response.headers["Content-Length"] == str(len(response.content))
 
 
@@ -96,3 +95,60 @@ def test_embedded_url_cannot_break_out_of_script(tmp_path, monkeypatch):
     text = response.content.decode()
     assert "</script><script>alert(1)</script>" not in text
     assert "\\u003c/script\\u003e" in text
+
+
+
+def _middleware_module(monkeypatch, *, attach_error: bool = False):
+    injection = importlib.import_module("paperless_local_ai_ui.injection")
+
+    documents = ModuleType("documents")
+    documents.__path__ = []
+    views = ModuleType("documents.views")
+
+    class IndexView:
+        pass
+
+    views.IndexView = IndexView
+    documents.views = views
+    monkeypatch.setitem(sys.modules, "documents", documents)
+    monkeypatch.setitem(sys.modules, "documents.views", views)
+
+    attached = []
+
+    if attach_error:
+        def fail(_index_view):
+            raise RuntimeError("attach failed")
+
+        monkeypatch.setattr(injection, "patch_index_view", fail)
+    else:
+        monkeypatch.setattr(injection, "patch_index_view", attached.append)
+
+    sys.modules.pop("paperless_local_ai_ui.middleware", None)
+    module = importlib.import_module("paperless_local_ai_ui.middleware")
+    return module, attached, IndexView
+
+
+def test_middleware_marks_responses_after_successful_attach(monkeypatch):
+    module, attached, index_view = _middleware_module(monkeypatch)
+    response = Response(content=b"")
+
+    middleware = module.PaperlessLocalAiUiMiddleware(lambda _request: response)
+    result = middleware(None)
+
+    assert attached == [index_view]
+    assert result is response
+    assert result.headers["X-Paperless-Local-AI-UI"] == "ready"
+
+
+def test_middleware_does_not_claim_ready_when_attach_fails(monkeypatch):
+    module, _attached, _index_view = _middleware_module(
+        monkeypatch,
+        attach_error=True,
+    )
+    response = Response(content=b"")
+
+    middleware = module.PaperlessLocalAiUiMiddleware(lambda _request: response)
+    result = middleware(None)
+
+    assert result is response
+    assert "X-Paperless-Local-AI-UI" not in result.headers


### PR DESCRIPTION
﻿## Summary

Fixes Paperless shortcut readiness detection when Paperless redirects unauthenticated requests to the login page.

## Changes

- registers a lightweight Paperless-side Django middleware from the optional integration app
- attaches the existing IndexView shortcut hook only in the Paperless web process
- exposes the readiness marker on all Paperless responses after the UI hook attached successfully
- keeps readiness independent of whether the shortcut itself is enabled or disabled
- allows the Control Center probe to verify setup through Paperless login redirects
- fixes re-enabling the shortcut after it has been disabled
- adds regression coverage for successful and failed integration attachment

No background polling, additional service, Docker socket access or TrueNAS API access is introduced.
