### PR TITLE
Add interactive Control Center demo for 0.3.8

### DIFF
--- a/.github/workflows/pages-demo.yml
+++ b/.github/workflows/pages-demo.yml
@@ -1,0 +1,69 @@
+name: deploy-control-center-demo
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/core/prompt_ui.py"
+      - "src/core/prompt_runtime.py"
+      - "src/common/app_config.py"
+      - "demo/**"
+      - "scripts/build_demo.py"
+      - "VERSION"
+      - ".github/workflows/pages-demo.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build static Control Center demo
+        run: python3 scripts/build_demo.py --output _site/demo
+
+      - name: Add Pages root redirect
+        run: |
+          cat > _site/index.html <<'EOF'
+          <!doctype html>
+          <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width,initial-scale=1">
+            <meta http-equiv="refresh" content="0; url=./demo/">
+            <title>paperless-local-ai demo</title>
+          </head>
+          <body>
+            <p><a href="./demo/">Open the paperless-local-ai Control Center demo</a></p>
+          </body>
+          </html>
+          EOF
+          touch _site/.nojekyll
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: _site
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 *.log
 .DS_Store
 /target/
+/_site/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## 0.3.8 - 2026-08-28
 
+### Added
+
+- add a browser-only live Control Center demo on GitHub Pages with synthetic Paperless, Ollama and OCR data, interactive prompt rendering, Hybrid and LLM-direct routing examples, versioned demo settings/history and resettable local browser state.
+
 ### Fixed
 
 - adapt the native Paperless suggestion bridge to the nested taxonomy-choice response schema introduced by Paperless-ngx 3.1, while preserving the Paperless-ngx 3.0.5 list response contract by negotiating against each Ollama request's JSON schema.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 Title, document type, date and sender/issuer are extracted in one structured LLM request. Content tags can use **Hybrid tagging**, which combines reviewed-document similarity with an LLM fallback, or **LLM direct**, where the model selects tags for every document. Sender names are resolved locally against existing Paperless correspondents. If the optional Paperless Suggestions integration is configured, plausible new names are exposed there for review; otherwise unmatched names remain for manual review. New correspondents are never auto-created.
 
+**[Try the live Control Center demo](https://lucaperl.github.io/paperless-local-ai/demo/)** — an interactive browser-only preview using synthetic Paperless, Ollama and OCR data.
+
 ## Highlights
 
 - **Improved scan OCR with PaddleOCR** — PP-OCRv6 Medium is the quality-focused default, with Small and Tiny profiles when lower inference cost matters.

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,21 @@
+# Control Center demo
+
+The public Control Center demo is a static, browser-only build of the same UI source that ships in `core-service`.
+
+- All Paperless documents, taxonomy values, correspondents, History entries, OCR state and model results are synthetic fixtures.
+- `/api/...` calls are intercepted in the browser by `demo/mock-api.js`; no Paperless, Ollama or OCR backend is contacted.
+- The generated page sets `connect-src 'none'` so browser network requests from the demo are blocked.
+- Configuration changes and restore actions use browser `localStorage` only and can be cleared with **Reset demo**.
+- Prompt previews are rendered from the current editable prompt draft, synthetic document text and synthetic taxonomy. A confident Hybrid demo route omits the Tagging prompt and `tags` schema field just like the production contract.
+
+Build locally from the repository root:
+
+```bash
+python scripts/build_demo.py --output _site/demo
+```
+
+Open `_site/demo/index.html` in a browser.
+
+The published demo is deployed by `.github/workflows/pages-demo.yml` to:
+
+<https://lucaperl.github.io/paperless-local-ai/demo/>

--- a/demo/mock-api.js
+++ b/demo/mock-api.js
@@ -1,0 +1,593 @@
+(() => {
+"use strict";
+
+const PROMPT_DEFAULT = __PROMPT_CONFIG_DEFAULT_JSON__;
+const PROMPT_PRESETS = __PROMPT_PRESETS_JSON__;
+const PLACEHOLDERS = __PLACEHOLDERS_JSON__;
+const APP_DEFAULT = __APP_CONFIG_DEFAULT_JSON__;
+
+const STORAGE_KEY = "paperless-local-ai-demo-v2";
+
+const TAGS = [
+  {id: 101, name: "Home", parent: null},
+  {id: 102, name: "Utilities", parent: 101},
+  {id: 103, name: "Finance", parent: null},
+  {id: 104, name: "Banking", parent: 103},
+  {id: 105, name: "Insurance", parent: 103},
+  {id: 106, name: "Work", parent: null},
+  {id: 107, name: "Vehicle", parent: null},
+  {id: 108, name: "Purchases", parent: null}
+];
+
+const DOCUMENT_TYPES = ["Invoice", "Contract", "Letter", "Statement", "Certificate"];
+const CORRESPONDENTS = ["Example Energy GmbH", "Demo Bank AG", "Sample Insurance AG"];
+
+const DOCUMENTS = {
+  4711: {
+    id: 4711,
+    current_title: "scan_2026_01_18",
+    current_created: "2026-01-18",
+    content: `Example Energy GmbH
+Customer: Erika Example
+Annual electricity statement
+Billing period: 2025-01-01 to 2025-12-31
+Meter number: DEMO-1842
+Electricity consumption: 2,184 kWh
+Invoice amount: EUR 684.27
+Invoice date: 2026-01-18
+This document is a synthetic fixture for the paperless-local-ai public demo.`,
+    history_evidence: {similarity: 0.91, support: 4, winner_share: 0.86, tags: ["Utilities"]},
+    examples: [
+      {id: 4601, title: "Electricity statement 2024", tags: ["Utilities"], excerpt: "Annual electricity statement and meter reading."},
+      {id: 4520, title: "Utility advance payment", tags: ["Utilities"], excerpt: "Monthly utility advance payment notice."}
+    ],
+    result: {
+      title: "Electricity annual statement 2025",
+      document_type: "Invoice",
+      correspondent: "Example Energy GmbH",
+      tags: ["Utilities"],
+      created: "2026-01-18"
+    }
+  },
+  4712: {
+    id: 4712,
+    current_title: "document_4712",
+    current_created: "2026-02-05",
+    content: `Sample Insurance AG
+Policy holder: Max Example
+Policy number: DEMO-90017
+Annual premium invoice for household insurance
+Coverage period: 2026-03-01 to 2027-02-28
+Premium due: EUR 148.00
+Issue date: 2026-02-05
+This document is a synthetic fixture for the paperless-local-ai public demo.`,
+    history_evidence: {similarity: 0.54, support: 1, winner_share: 0.51, tags: ["Insurance"]},
+    examples: [
+      {id: 4505, title: "Household insurance renewal", tags: ["Insurance"], excerpt: "Renewal notice for household insurance."},
+      {id: 4472, title: "Liability insurance premium", tags: ["Insurance"], excerpt: "Annual insurance premium notice."},
+      {id: 4421, title: "Bank account statement", tags: ["Banking"], excerpt: "Monthly account statement with transactions."}
+    ],
+    result: {
+      title: "Household insurance premium 2026",
+      document_type: "Invoice",
+      correspondent: "Sample Insurance AG",
+      tags: ["Insurance"],
+      created: "2026-02-05"
+    }
+  },
+  4713: {
+    id: 4713,
+    current_title: "incoming_document",
+    current_created: "2026-03-03",
+    content: `Example Services Ltd.
+Reference: DEMO-771
+General information notice
+Thank you for your enquiry. This letter confirms that your request was received.
+No invoice, contract, insurance policy, employment matter, vehicle matter or banking transaction is contained in this notice.
+Issue date: 2026-03-03
+This document is a synthetic fixture for the paperless-local-ai public demo.`,
+    history_evidence: null,
+    examples: [
+      {id: 4388, title: "General service notice", tags: [], excerpt: "Generic acknowledgement without a filing category."}
+    ],
+    result: {
+      title: "Request acknowledgement",
+      document_type: "Letter",
+      correspondent: "Example Services Ltd.",
+      tags: [],
+      created: "2026-03-03"
+    }
+  }
+};
+
+const HISTORY_HEALTH = {
+  status: "Ready",
+  cache_state: "ready",
+  stale: false,
+  reviewed_documents: 42,
+  source: {reviewed_documents: 42},
+  tags_represented: 7,
+  eligible_tags: 8,
+  estimated_reuse_sample_size: 42,
+  estimated_reuse_percent: 57,
+  potential_inconsistency_count: 1,
+  last_updated: "2026-08-28T08:42:00Z",
+  per_tag: [
+    {name: "Utilities", count: 9, status: "Strong"},
+    {name: "Banking", count: 8, status: "Strong"},
+    {name: "Insurance", count: 6, status: "Good"},
+    {name: "Work", count: 7, status: "Good"},
+    {name: "Vehicle", count: 4, status: "Building"},
+    {name: "Purchases", count: 5, status: "Good"},
+    {name: "Home", count: 3, status: "Building"}
+  ],
+  potential_inconsistencies: [
+    {
+      documents: 3,
+      tag_sets: [{tags: ["Banking"], count: 2}, {tags: ["Finance"], count: 1}],
+      examples: [
+        {id: 4320, title: "Monthly account statement", tags: ["Banking"]},
+        {id: 4311, title: "Account information", tags: ["Finance"]},
+        {id: 4298, title: "Quarterly account statement", tags: ["Banking"]}
+      ],
+      truncated: false
+    }
+  ]
+};
+
+const clone = value => JSON.parse(JSON.stringify(value));
+const nowIso = () => new Date().toISOString();
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+function initialState() {
+  const promptConfig = clone(PROMPT_DEFAULT);
+  promptConfig.version = 3;
+  promptConfig.updated_at = "2026-08-28T08:30:00Z";
+  promptConfig.tag_guidance = {
+    "102": "Electricity, gas, water and other household utility bills or statements.",
+    "104": "Bank accounts, account statements and banking correspondence.",
+    "105": "Insurance policies, premiums, claims and insurer correspondence."
+  };
+
+  const appConfig = clone(APP_DEFAULT);
+  appConfig.version = 2;
+  appConfig.updated_at = "2026-08-28T08:20:00Z";
+  appConfig.connections.paperless_url = "http://paperless:8000";
+  appConfig.connections.ollama_url = "http://ollama:11434";
+  appConfig.ocr.language = "en";
+  appConfig.ocr.model_profile = "medium";
+
+  return {
+    promptConfig,
+    appConfig,
+    promptHistory: [
+      {
+        file: "prompt-config-v0002-demo.json",
+        version: 2,
+        updated_at: "2026-08-27T18:12:00Z",
+        summary: "qwen3.5:4b · Hybrid tagging",
+        config: {...clone(promptConfig), version: 2, updated_at: "2026-08-27T18:12:00Z"}
+      },
+      {
+        file: "prompt-config-v0001-demo.json",
+        version: 1,
+        updated_at: "2026-08-26T09:00:00Z",
+        summary: "Initial demo classification settings",
+        config: {...clone(PROMPT_DEFAULT), version: 1, updated_at: "2026-08-26T09:00:00Z"}
+      }
+    ],
+    appHistory: [
+      {
+        file: "app-config-v0001-demo.json",
+        version: 1,
+        updated_at: "2026-08-27T17:55:00Z",
+        summary: "Metadata writes enabled · PP-OCRv6 Medium · 3000 px",
+        config: {...clone(appConfig), version: 1, updated_at: "2026-08-27T17:55:00Z"}
+      }
+    ],
+    historyLastUpdated: HISTORY_HEALTH.last_updated
+  };
+}
+
+function loadState() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) return JSON.parse(raw);
+  } catch (_) {}
+  return initialState();
+}
+
+let state = loadState();
+
+function persist() {
+  try { localStorage.setItem(STORAGE_KEY, JSON.stringify(state)); } catch (_) {}
+}
+
+function reset() {
+  try { localStorage.removeItem(STORAGE_KEY); } catch (_) {}
+  location.reload();
+}
+
+function publicHistory(items) {
+  return (items || []).map(item => {
+    const copy = {...item};
+    delete copy.config;
+    return copy;
+  });
+}
+
+function bodyJson(opts) {
+  if (!opts || opts.body == null || opts.body === "") return {};
+  if (typeof opts.body === "string") {
+    try { return JSON.parse(opts.body); } catch (_) { return {}; }
+  }
+  return opts.body;
+}
+
+function placeholdersIn(text) {
+  return [...String(text || "").matchAll(/{{\s*([A-Z0-9_]+)\s*}}/g)].map(match => match[1]);
+}
+
+function validatePromptConfig(raw) {
+  if (!raw || typeof raw !== "object") throw new Error("Configuration must be a JSON object.");
+  for (const key of ["system_prompt", "classification_template", "tagging_prompt", "model"]) {
+    if (!String(raw[key] || "").trim()) throw new Error(`${key} must not be empty`);
+  }
+
+  const system = placeholdersIn(raw.system_prompt);
+  const classification = placeholdersIn(raw.classification_template);
+  const tagging = placeholdersIn(raw.tagging_prompt);
+  const all = [...system, ...classification, ...tagging];
+  const allowed = new Set(Object.keys(PLACEHOLDERS));
+  const unknown = [...new Set(all.filter(name => !allowed.has(name)))].sort();
+  if (unknown.length) throw new Error(`Unknown placeholders: ${unknown.join(", ")}`);
+  if (system.includes("DOCUMENT_TEXT")) throw new Error("{{DOCUMENT_TEXT}} must not appear in the system prompt for security reasons");
+  if (!classification.includes("DOCUMENT_TEXT")) throw new Error("classification_template must contain {{DOCUMENT_TEXT}}");
+
+  const tagOnly = new Set(["TAGS_JSON", "TAGS_LINES", "MAX_TAGS", "TAG_GUIDANCE", "TAG_EXAMPLES"]);
+  const misplaced = [...new Set([...system, ...classification].filter(name => tagOnly.has(name)))].sort();
+  if (misplaced.length) throw new Error(`Tagging placeholders belong in tagging_prompt: ${misplaced.join(", ")}`);
+  if (!["history_assisted", "llm_only"].includes(raw.tagging_mode)) throw new Error("Unsupported tagging mode");
+  if (!Number.isInteger(Number(raw.max_tags)) || Number(raw.max_tags) < 1 || Number(raw.max_tags) > 10) {
+    throw new Error("max_tags must be between 1 and 10");
+  }
+  return clone(raw);
+}
+
+function validateAppConfig(raw) {
+  if (!raw || typeof raw !== "object") throw new Error("App configuration must be a JSON object.");
+  for (const key of ["paperless_url", "ollama_url"]) {
+    const value = String(raw.connections?.[key] || "");
+    if (!/^https?:\/\/[^/]+/i.test(value)) throw new Error(`connections.${key} must be a complete http(s) URL`);
+  }
+  const workflow = raw.workflow || {};
+  const technical = [workflow.llm_queue_tag, workflow.llm_error_tag, workflow.review_tag].map(x => String(x || "").trim());
+  if (technical.some(x => !x)) throw new Error("Technical workflow tags must not be empty");
+  if (new Set(technical.map(x => x.toLowerCase())).size !== technical.length) {
+    throw new Error("Technical workflow tags must have distinct names");
+  }
+  return clone(raw);
+}
+
+function savePromptConfig(raw) {
+  const candidate = validatePromptConfig(raw);
+  const previous = clone(state.promptConfig);
+  state.promptHistory.unshift({
+    file: `prompt-config-v${String(previous.version).padStart(4, "0")}-demo-${Date.now()}.json`,
+    version: previous.version,
+    updated_at: previous.updated_at,
+    summary: `${previous.model} · ${previous.tagging_mode === "history_assisted" ? "Hybrid tagging" : "LLM direct"}`,
+    config: previous
+  });
+  candidate.version = Number(previous.version || 0) + 1;
+  candidate.updated_at = nowIso();
+  state.promptConfig = candidate;
+  persist();
+  return clone(candidate);
+}
+
+function saveAppConfig(raw) {
+  const candidate = validateAppConfig(raw);
+  const previous = clone(state.appConfig);
+  state.appHistory.unshift({
+    file: `app-config-v${String(previous.version).padStart(4, "0")}-demo-${Date.now()}.json`,
+    version: previous.version,
+    updated_at: previous.updated_at,
+    summary: `${previous.runtime?.dry_run ? "Metadata dry run" : "Metadata writes enabled"} · ${previous.ocr?.version || "PP-OCRv6"} ${String(previous.ocr?.model_profile || "medium").replace(/^./, c => c.toUpperCase())} · ${previous.ocr?.max_side_pixels || 3000} px`,
+    config: previous
+  });
+  candidate.version = Number(previous.version || 0) + 1;
+  candidate.updated_at = nowIso();
+  state.appConfig = candidate;
+  persist();
+  return clone(candidate);
+}
+
+function eligibleTagNames() {
+  const parents = new Set(TAGS.filter(tag => tag.parent != null).map(tag => tag.parent));
+  return TAGS.filter(tag => !parents.has(tag.id)).map(tag => tag.name);
+}
+
+function guidanceText(config) {
+  const lines = [];
+  const guidance = config.tag_guidance || {};
+  for (const tag of TAGS) {
+    const value = String(guidance[String(tag.id)] || "").trim();
+    if (value) lines.push(`- ${tag.name}: ${value}`);
+  }
+  return lines.length ? lines.join("\n") : "(none)";
+}
+
+function examplesText(doc, route) {
+  if (route !== "llm_fallback") return "";
+  const examples = doc.examples || [];
+  if (!examples.length) return "(none)";
+  return examples.map(example =>
+    `- ID ${example.id} · ${example.title} · tags: ${(example.tags || []).join(" + ") || "(none)"}\n  ${example.excerpt}`
+  ).join("\n");
+}
+
+function routeFor(config, doc) {
+  if (config.tagging_mode === "llm_only") return "llm_only";
+  const evidence = doc.history_evidence;
+  if (!evidence) return "llm_fallback";
+  const settings = state.appConfig.history || {};
+  const passes =
+    evidence.similarity >= Number(settings.match_similarity ?? 0.62) &&
+    evidence.support >= Number(settings.min_support ?? 2) &&
+    evidence.winner_share >= Number(settings.min_winner_share ?? 0.50);
+  return passes ? "history_match" : "llm_fallback";
+}
+
+function templateValues(config, doc, route) {
+  const tags = eligibleTagNames();
+  return {
+    DOCUMENT_TEXT: doc.content,
+    DOCUMENT_ID: String(doc.id),
+    CURRENT_TITLE: doc.current_title || "",
+    CURRENT_CREATED: doc.current_created || "",
+    TAGS_JSON: JSON.stringify(tags, null, 2),
+    TAGS_LINES: tags.join("\n"),
+    MAX_TAGS: String(config.max_tags),
+    TAG_GUIDANCE: guidanceText(config),
+    TAG_EXAMPLES: examplesText(doc, route),
+    DOCUMENT_TYPES_JSON: JSON.stringify(DOCUMENT_TYPES, null, 2),
+    DOCUMENT_TYPES_LINES: DOCUMENT_TYPES.join("\n"),
+    CORRESPONDENTS_JSON: JSON.stringify(CORRESPONDENTS, null, 2),
+    CORRESPONDENTS_LINES: CORRESPONDENTS.join("\n")
+  };
+}
+
+function renderTemplate(text, values) {
+  return String(text || "").replace(/{{\s*([A-Z0-9_]+)\s*}}/g, (match, name) =>
+    Object.prototype.hasOwnProperty.call(values, name) ? String(values[name]) : match
+  );
+}
+
+function outputSchema(config, route) {
+  const properties = {
+    title: {type: "string"},
+    document_type: {type: "string", enum: ["", ...DOCUMENT_TYPES]},
+    correspondent: {type: "string"},
+    created: {type: "string", pattern: "^$|^\\d{4}-\\d{2}-\\d{2}$"}
+  };
+  const required = ["title", "document_type", "correspondent", "created"];
+  if (route !== "history_match") {
+    properties.tags = {
+      type: "array",
+      items: {type: "string", enum: eligibleTagNames()},
+      maxItems: Number(config.max_tags),
+      uniqueItems: true
+    };
+    required.push("tags");
+  }
+  return {type: "object", properties, required, additionalProperties: false};
+}
+
+function previewPayload(config, doc, includeModelResult) {
+  validatePromptConfig(config);
+  const route = routeFor(config, doc);
+  const values = templateValues(config, doc, route);
+  const systemPrompt = renderTemplate(config.system_prompt, values);
+  const basePrompt = renderTemplate(config.classification_template, values);
+  const taggingPrompt = route === "history_match" ? "" : renderTemplate(config.tagging_prompt, values);
+  const userPrompt = taggingPrompt ? `${basePrompt}\n\n${taggingPrompt}` : basePrompt;
+  const schema = outputSchema(config, route);
+
+  const evidence = doc.history_evidence;
+  const tagging = {
+    strategy: config.tagging_mode,
+    route,
+    history_match: route === "history_match" && evidence ? {
+      tags: evidence.tags,
+      similarity: evidence.similarity,
+      support: evidence.support,
+      winner_share: evidence.winner_share
+    } : null,
+    reviewed_examples: route === "llm_fallback" ? clone(doc.examples || []) : []
+  };
+
+  const payload = {
+    rendered: {system_prompt: systemPrompt, user_prompt: userPrompt, schema},
+    taxonomy: {tags: clone(TAGS), document_types: clone(DOCUMENT_TYPES), correspondents: clone(CORRESPONDENTS)},
+    tagging,
+    meta: {
+      demo: true,
+      document_id: doc.id,
+      current_title: doc.current_title,
+      current_created: doc.current_created,
+      document_characters: doc.content.length,
+      model: config.model,
+      note: "Synthetic browser-only demo fixture; Paperless and Ollama were not contacted."
+    }
+  };
+
+  if (includeModelResult) {
+    const suggestion = clone(doc.result);
+    if (route === "history_match" && evidence) suggestion.tags = clone(evidence.tags);
+    const corrStatus = !suggestion.correspondent
+      ? "empty"
+      : CORRESPONDENTS.includes(suggestion.correspondent)
+        ? "existing_exact"
+        : "new_suggestion";
+    payload.suggestion = suggestion;
+    payload.validation_errors = [];
+    payload.correspondent_resolution = {
+      status: corrStatus,
+      suggestion: suggestion.correspondent,
+      matched_name: corrStatus === "existing_exact" ? suggestion.correspondent : null
+    };
+    const approxPromptTokens = Math.max(1, Math.round((systemPrompt.length + userPrompt.length) / 4));
+    payload.performance = {
+      model: config.model,
+      inference_seconds: doc.id === 4711 ? 7.4 : doc.id === 4712 ? 8.8 : 6.9,
+      prompt_eval_count: approxPromptTokens,
+      eval_count: 78,
+      eval_tokens_per_second: 10.5,
+      simulated: true
+    };
+  }
+  return payload;
+}
+
+function taggingState() {
+  const history = clone(HISTORY_HEALTH);
+  history.last_updated = state.historyLastUpdated || history.last_updated;
+  return {tags: clone(TAGS), tag_guidance: clone(state.promptConfig.tag_guidance || {}), history};
+}
+
+function ocrRecovery() {
+  return {
+    state: {status: "idle", attempt: 0, max_attempts: 4, request_id: "", retry_now_requested: false, last_error: ""},
+    failures: []
+  };
+}
+
+async function api(path, opts = {}) {
+  const method = String(opts.method || "GET").toUpperCase();
+  const body = bodyJson(opts);
+
+  if (path === "/api/state" && method === "GET") {
+    return {
+      config: clone(state.promptConfig),
+      presets: clone(PROMPT_PRESETS),
+      placeholders: clone(PLACEHOLDERS),
+      config_sha256: "demo",
+      prompt_hashes: {config_sha256: "demo"}
+    };
+  }
+  if (path === "/api/history" && method === "GET") return {items: publicHistory(state.promptHistory)};
+  if (path === "/api/config/validate" && method === "POST") {
+    validatePromptConfig(body.config);
+    return {ok: true, config_sha256: "demo-valid"};
+  }
+  if (path === "/api/config/save" && method === "POST") {
+    const config = savePromptConfig(body.config);
+    return {ok: true, config, history: publicHistory(state.promptHistory)};
+  }
+  if (path === "/api/history/restore" && method === "POST") {
+    const item = state.promptHistory.find(entry => entry.file === body.file);
+    if (!item || !item.config) throw new Error("Demo history version not found");
+    const config = savePromptConfig(item.config);
+    return {ok: true, config, history: publicHistory(state.promptHistory)};
+  }
+
+  if (path === "/api/tagging/state" && method === "GET") return taggingState();
+  if (path === "/api/tagging/refresh" && method === "POST") {
+    await sleep(300);
+    state.historyLastUpdated = nowIso();
+    persist();
+    return taggingState();
+  }
+
+  if ((path === "/api/preview" || path === "/api/test") && method === "POST") {
+    const id = Number(body.document_id);
+    const doc = DOCUMENTS[id];
+    if (!doc) throw new Error("Demo document not found. Try 4711, 4712 or 4713.");
+    const config = validatePromptConfig(body.config);
+    await sleep(path === "/api/test" ? 650 : 120);
+    return previewPayload(config, doc, path === "/api/test");
+  }
+
+  if (path === "/api/app/state" && method === "GET") {
+    return {
+      config: clone(state.appConfig),
+      config_sha256: "demo",
+      history: publicHistory(state.appHistory),
+      token_configured: true,
+      paperless_ui_integration_ready: true
+    };
+  }
+  if (path === "/api/app/history" && method === "GET") return {items: publicHistory(state.appHistory)};
+  if (path === "/api/app/validate" && method === "POST") {
+    validateAppConfig(body.config);
+    return {ok: true, config_sha256: "demo-valid"};
+  }
+  if (path === "/api/app/save" && method === "POST") {
+    const config = saveAppConfig(body.config);
+    return {ok: true, config, history: publicHistory(state.appHistory), token_configured: true, paperless_ui_integration_ready: true};
+  }
+  if (path === "/api/app/history/restore" && method === "POST") {
+    const item = state.appHistory.find(entry => entry.file === body.file);
+    if (!item || !item.config) throw new Error("Demo app-history version not found");
+    const config = saveAppConfig(item.config);
+    return {ok: true, config, history: publicHistory(state.appHistory), token_configured: true, paperless_ui_integration_ready: true};
+  }
+  if (path === "/api/app/connections/test" && method === "POST") {
+    validateAppConfig(body.config);
+    await sleep(350);
+    return {
+      paperless: {ok: true, detail: "Synthetic Paperless connection"},
+      ollama: {ok: true, detail: "Synthetic Ollama connection"}
+    };
+  }
+  if (path === "/api/app/paperless-ui/status" && method === "GET") {
+    return {ok: true, reachable: true, package_ready: true, detail: "Synthetic Paperless UI integration verified"};
+  }
+  if (path === "/api/app/paperless-ui" && method === "POST") {
+    const updated = clone(state.appConfig);
+    updated.paperless_ui = updated.paperless_ui || {};
+    updated.paperless_ui.enabled = Boolean(body.enabled);
+    updated.paperless_ui.control_center_url = body.enabled ? "https://example.invalid/control-center" : "";
+    const config = saveAppConfig(updated);
+    return {ok: true, config, history: publicHistory(state.appHistory), token_configured: true, paperless_ui_integration_ready: true};
+  }
+  if (path === "/api/app/ocr/health" && method === "GET") {
+    return {
+      ok: true,
+      health: {
+        ok: true,
+        version: state.appConfig.ocr?.version || "PP-OCRv6",
+        model_profile: state.appConfig.ocr?.model_profile || "medium",
+        device: state.appConfig.ocr?.device || "cpu",
+        simulated: true
+      },
+      recovery: ocrRecovery()
+    };
+  }
+  if (path === "/api/app/ocr/recovery" && method === "GET") return ocrRecovery();
+  if (path === "/api/app/ocr/failures/dismiss" && method === "POST") return {ok: true, removed: false};
+  if (path === "/api/app/ocr/retry-now" && method === "POST") return {ok: true, trigger: {request_id: body.request_id || "", simulated: true}};
+  if (path === "/api/health" && method === "GET") return {ok: true, demo: true};
+
+  throw new Error(`Demo endpoint is not implemented: ${method} ${path}`);
+}
+
+window.PLAI_DEMO = {api, reset};
+
+document.addEventListener("DOMContentLoaded", () => {
+  const docId = document.getElementById("docId");
+  if (docId && !docId.value) docId.value = "4711";
+
+  document.getElementById("demo-reset")?.addEventListener("click", reset);
+
+  document.querySelectorAll("[data-demo-document]").forEach(button => {
+    button.addEventListener("click", () => {
+      if (docId) docId.value = button.dataset.demoDocument;
+      document.querySelector('[data-page="classification"]')?.click();
+      document.querySelector('[data-tab="class-test"]')?.click();
+      docId?.focus();
+    });
+  });
+});
+})();

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -28,7 +28,9 @@ The included plugin is verified against OCRmyPDF **17.4.2**, specifically the na
 
 A newer Paperless/OCRmyPDF release should be treated as unverified until the plugin contract is checked.
 
-The new-correspondent suggestion bridge is also version-sensitive because it depends on Paperless' AI classification-suggestion request shape. Its tested target is Paperless-ngx **3.0.5**.
+The new-correspondent suggestion bridge is also version-sensitive because it depends on Paperless' AI classification-suggestion request shape. It supports the list-based taxonomy response contract used by Paperless-ngx **3.0.5** and the nested `existing_ids` / `new_names` taxonomy-choice schema introduced by Paperless-ngx **3.1.0**. The bridge derives the response shape from each request schema instead of hardcoding a Paperless version.
+
+This does not by itself broaden the tested OCR/plugin reference environment above; newer Paperless/OCRmyPDF combinations remain unverified until the OCR plugin contract is checked.
 
 Paperless 2.x is not a supported target for this OCR/plugin path.
 

--- a/scripts/build_demo.py
+++ b/scripts/build_demo.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from pathlib import Path
+
+HTML_START = "HTML = r'''"
+HTML_END = "'''.replace(\"__TAGGING_DOCS_URL__\""
+
+LIVE_REPO = "https://github.com/lucaperl/paperless-local-ai"
+DOCS_BASE = f"{LIVE_REPO}/blob/main"
+
+API_FETCH = '''async function api(path,opts={}){const r=await fetch(path,{headers:{'Content-Type':'application/json'},...opts});const t=await r.text();let data;try{data=JSON.parse(t)}catch{data={error:t}}if(!r.ok)throw new Error(data.error||`${r.status} ${r.statusText}`);return data}'''
+API_MOCK = '''async function api(path,opts={}){return window.PLAI_DEMO.api(path,opts)}'''
+
+CSP_META = '''<meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'">'''
+
+DEMO_CSS = r'''
+.demo-banner{position:sticky;top:0;z-index:30;min-height:44px;padding:8px 18px;display:flex;align-items:center;gap:10px;flex-wrap:wrap;background:#201909;border-bottom:1px solid #6a5127;color:#f7ddb0}
+.demo-banner strong{color:#ffd58b}.demo-banner .demo-copy{color:#d9c39e}.demo-banner .demo-docs{display:flex;align-items:center;gap:6px;flex-wrap:wrap}.demo-banner button{width:auto}
+.demo-banner .demo-doc{border:1px solid #6a5127;background:#2b2110;color:#ffd58b;border-radius:7px;padding:4px 8px}.demo-banner .demo-doc:hover{background:#3a2b12}
+.demo-banner .demo-reset{margin-left:auto;border:1px solid #6a5127;background:#2b2110;color:#f7ddb0;border-radius:7px;padding:5px 9px}.demo-banner .demo-reset:hover{background:#3a2b12}
+.topbar{top:44px}
+@media(max-width:760px){.demo-banner{position:static;padding:9px 12px}.demo-banner .demo-reset{margin-left:0}.topbar{top:0}}
+'''
+
+DEMO_BANNER = r'''<div class="demo-banner" role="status">
+  <strong>Demo mode</strong>
+  <span class="demo-copy">Browser-only synthetic Paperless, Ollama and OCR data.</span>
+  <span class="demo-docs">Try:
+    <button type="button" class="demo-doc" data-demo-document="4711">4711 · History match</button>
+    <button type="button" class="demo-doc" data-demo-document="4712">4712 · LLM fallback</button>
+    <button type="button" class="demo-doc" data-demo-document="4713">4713 · conservative</button>
+  </span>
+  <button type="button" class="demo-reset" id="demo-reset">Reset demo</button>
+</div>'''
+
+
+class StaticEvalError(ValueError):
+    pass
+
+
+def static_eval(node: ast.AST, env: dict[str, object]) -> object:
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.Name):
+        if node.id not in env:
+            raise StaticEvalError(node.id)
+        return env[node.id]
+    if isinstance(node, ast.Dict):
+        return {
+            static_eval(key, env): static_eval(value, env)
+            for key, value in zip(node.keys, node.values, strict=True)
+        }
+    if isinstance(node, ast.List):
+        return [static_eval(item, env) for item in node.elts]
+    if isinstance(node, ast.Tuple):
+        return tuple(static_eval(item, env) for item in node.elts)
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        return -static_eval(node.operand, env)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        return static_eval(node.left, env) + static_eval(node.right, env)
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and len(node.args) == 1 and not node.keywords:
+        value = static_eval(node.args[0], env)
+        if node.func.id == "list":
+            return list(value)
+        if node.func.id == "tuple":
+            return tuple(value)
+    raise StaticEvalError(ast.dump(node, include_attributes=False))
+
+
+def source_constants(path: Path) -> dict[str, object]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    env: dict[str, object] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if not isinstance(target, ast.Name):
+            continue
+        try:
+            env[target.id] = static_eval(node.value, env)
+        except StaticEvalError:
+            continue
+    return env
+
+
+def js_json(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":")).replace("</", "<\\/")
+
+
+def extract_control_center(source: Path) -> str:
+    text = source.read_text(encoding="utf-8")
+    start = text.find(HTML_START)
+    if start < 0:
+        raise SystemExit(f"Control Center HTML start marker missing in {source}")
+    start += len(HTML_START)
+    tail = text[start:]
+    end = tail.find(HTML_END)
+    if end < 0:
+        raise SystemExit(f"Control Center HTML end marker missing in {source}")
+    html = tail[:end]
+    required = [
+        "paperless-local-ai Control Center",
+        "__TAGGING_DOCS_URL__",
+        "__PAPERLESS_SETUP_DOCS_URL__",
+        "__APP_VERSION__",
+        API_FETCH,
+    ]
+    missing = [marker for marker in required if marker not in html]
+    if missing:
+        raise SystemExit(f"Control Center demo build contract changed; missing: {missing}")
+    return html
+
+
+def render_mock_source(repo: Path) -> str:
+    mock_path = repo / "demo" / "mock-api.js"
+    mock = mock_path.read_text(encoding="utf-8")
+
+    prompt_constants = source_constants(repo / "src" / "core" / "prompt_runtime.py")
+    app_constants = source_constants(repo / "src" / "common" / "app_config.py")
+
+    required_prompt = ["DEFAULT_CONFIG", "PROMPT_PRESETS", "PLACEHOLDERS"]
+    missing_prompt = [name for name in required_prompt if name not in prompt_constants]
+    if missing_prompt:
+        raise SystemExit(f"Could not statically read prompt defaults: {missing_prompt}")
+    if "DEFAULT_CONFIG" not in app_constants:
+        raise SystemExit("Could not statically read App Settings defaults")
+
+    replacements = {
+        "__PROMPT_CONFIG_DEFAULT_JSON__": js_json(prompt_constants["DEFAULT_CONFIG"]),
+        "__PROMPT_PRESETS_JSON__": js_json(prompt_constants["PROMPT_PRESETS"]),
+        "__PLACEHOLDERS_JSON__": js_json(prompt_constants["PLACEHOLDERS"]),
+        "__APP_CONFIG_DEFAULT_JSON__": js_json(app_constants["DEFAULT_CONFIG"]),
+    }
+    for marker, value in replacements.items():
+        if marker not in mock:
+            raise SystemExit(f"Demo mock marker missing: {marker}")
+        mock = mock.replace(marker, value)
+
+    unresolved = [marker for marker in replacements if marker in mock]
+    if unresolved:
+        raise SystemExit(f"Unresolved demo mock markers: {unresolved}")
+    return mock
+
+
+def build_html(repo: Path) -> str:
+    html = extract_control_center(repo / "src" / "core" / "prompt_ui.py")
+    version = (repo / "VERSION").read_text(encoding="utf-8").strip() or "dev"
+
+    html = html.replace("__TAGGING_DOCS_URL__", f"{DOCS_BASE}/docs/tagging.md")
+    html = html.replace("__PAPERLESS_SETUP_DOCS_URL__", f"{DOCS_BASE}/docs/paperless-setup.md")
+    html = html.replace("__APP_VERSION__", f"{version} · demo")
+
+    html = html.replace(
+        '<meta name="viewport" content="width=device-width,initial-scale=1">',
+        '<meta name="viewport" content="width=device-width,initial-scale=1">\n' + CSP_META,
+        1,
+    )
+    html = html.replace("</style>", DEMO_CSS + "\n</style>", 1)
+    html = html.replace(
+        '<main class="main">\n<header class="topbar">',
+        '<main class="main">\n' + DEMO_BANNER + '\n<header class="topbar">',
+        1,
+    )
+
+    if API_FETCH not in html:
+        raise SystemExit("Production API fetch function changed; refusing to build a stale demo shim")
+    html = html.replace(API_FETCH, API_MOCK, 1)
+
+    mock = render_mock_source(repo)
+    if "<script>" not in html:
+        raise SystemExit("Control Center script marker missing")
+    html = html.replace("<script>", "<script>\n" + mock + "\n</script>\n<script>", 1)
+
+    if "fetch(path" in html:
+        raise SystemExit("Demo output still contains the production API fetch implementation")
+    if "connect-src 'none'" not in html:
+        raise SystemExit("Demo output is missing the network-blocking CSP")
+    if 'data-demo-document="4711"' not in html:
+        raise SystemExit("Demo banner was not injected")
+    return html
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build the static browser-only Control Center demo.")
+    parser.add_argument("--output", default="_site/demo", help="Output directory (default: _site/demo)")
+    args = parser.parse_args()
+
+    repo = Path(__file__).resolve().parents[1]
+    output = Path(args.output)
+    if not output.is_absolute():
+        output = repo / output
+    output.mkdir(parents=True, exist_ok=True)
+
+    html = build_html(repo)
+    (output / "index.html").write_text(html, encoding="utf-8", newline="\n")
+    print(f"Built Control Center demo: {output / 'index.html'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_demo_build.py
+++ b/tests/test_demo_build.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_static_control_center_demo_builds(tmp_path):
+    output = tmp_path / "demo"
+    subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "build_demo.py"),
+            "--output",
+            str(output),
+        ],
+        cwd=ROOT,
+        check=True,
+    )
+    html = (output / "index.html").read_text(encoding="utf-8")
+
+    assert "paperless-local-ai Control Center" in html
+    assert "Demo mode" in html
+    assert "4711 · History match" in html
+    assert "4712 · LLM fallback" in html
+    assert "4713 · conservative" in html
+    assert "window.PLAI_DEMO.api" in html
+    assert "connect-src 'none'" in html
+    assert "fetch(path" not in html
+    assert "__PROMPT_CONFIG_DEFAULT_JSON__" not in html
+    assert "__APP_CONFIG_DEFAULT_JSON__" not in html
+    assert "__TAGGING_DOCS_URL__" not in html
+    assert "__PAPERLESS_SETUP_DOCS_URL__" not in html
+    assert "__APP_VERSION__" not in html
+
+
+def test_demo_mock_has_no_network_client():
+    source = (ROOT / "demo" / "mock-api.js").read_text(encoding="utf-8")
+    assert "fetch(" not in source
+    assert "XMLHttpRequest" not in source
+    assert "WebSocket(" not in source


### PR DESCRIPTION
Adds the public browser-only Control Center demo for 0.3.8, using synthetic Paperless/Ollama/OCR data and the production Control Center UI source. Also finishes the compatibility documentation for the Paperless 3.1 suggestion-schema support merged in #85.