### PR TITLE
Update project scope and RAG documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,15 @@ This file describes project invariants for coding agents and contributors.
 
 ## Project scope
 
-`paperless-local-ai` is a small companion stack for Paperless-ngx. It improves scan OCR through Paperless/OCRmyPDF plus a local PaddleOCR service, applies text-only metadata classification through an external Ollama server, and optionally provides a deliberately lightweight local RAG chat inside the Paperless UI.
+`paperless-local-ai` is a small **CPU-first local-AI companion stack** for Paperless-ngx. It improves scan OCR through Paperless/OCRmyPDF plus a local PaddleOCR service, applies text-only metadata classification through an external Ollama server, and provides a deliberately lightweight local document-chat/RAG path inside the Paperless UI.
 
-The lightweight RAG/document-chat scope is an explicit project decision. Keep it bounded: do not turn the project into a bundled Paperless/Ollama distribution, a dedicated vector-database stack, an agent framework, or an uncontrolled multi-call RAG pipeline.
+OCR, metadata automation and document chat are all explicit supported project capabilities. The hardware philosophy is also an invariant: useful operation on modest CPU-only home-server hardware must remain a primary design target. Features may become more capable, but they must not quietly turn the default architecture into a GPU-required or high-concurrency AI stack.
+
+Keep the scope bounded: do not turn the project into a bundled Paperless/Ollama distribution, a dedicated vector-database stack, an agent framework, or an uncontrolled multi-call RAG pipeline.
 
 ## Architecture invariants
 
+- Modest CPU-only hardware is a first-class target. New default behavior must not require a GPU, assume multiple heavyweight models can stay resident concurrently, or bypass the shared resource-serialization design without an explicit project decision.
 - One Compose application, two long-running services: `ocr-service` and `core-service`. The core service hosts metadata polling, the Control Center, the optional suggestion bridge and the lightweight History broker in one persistent Rust process.
 - Two images only: OCR image and core image.
 - Ollama stays external.

--- a/README.md
+++ b/README.md
@@ -3,41 +3,45 @@
 
 # paperless-local-ai
 
-**Improved OCR with PaddleOCR and efficient local-LLM metadata automation for Paperless-ngx — designed for modest CPU-only hardware.**
+**Local AI for Paperless-ngx: better OCR, metadata automation and document chat — designed for modest CPU-only hardware.**
 
-`paperless-local-ai` uses **PaddleOCR instead of Tesseract** for scanned pages that need OCR and applies Paperless metadata with a local Ollama model. It integrates into Paperless' OCRmyPDF import path, so Paperless stays the document system of record.
+`paperless-local-ai` is a focused companion stack that adds a local-AI layer around an existing Paperless-ngx installation without replacing Paperless or bundling Ollama. It has three first-class capabilities:
 
-Title, document type, date and sender/issuer are extracted in one structured LLM request. Content tags can use **Hybrid tagging**, which combines reviewed-document similarity with an LLM fallback, or **LLM direct**, where the model selects tags for every document. Sender names are resolved locally against existing Paperless correspondents. If the optional Paperless Suggestions integration is configured, plausible new names are exposed there for review; otherwise unmatched names remain for manual review. New correspondents are never auto-created.
+- **scan OCR** with PaddleOCR / PP-OCRv6 through Paperless' OCRmyPDF import path;
+- **structured metadata automation** for title, document type, date, correspondent and tags;
+- **lightweight document chat** with a local SQLite RAG index and a chat panel inside Paperless.
+
+The project is deliberately **CPU-first and resource-aware**. Heavy OCR, history, embedding and chat/model work share one AI slot instead of competing for RAM and CPU. Heavy helpers are started on demand and released again, Ollama models are explicitly unloaded after work, and RAG uses SQLite plus exact cosine retrieval instead of a separate vector database or agent framework. A GPU can make inference faster, but it is not required by the architecture.
+
+Paperless remains the document system of record. The original document is preserved, OCR/searchable archives and metadata stay in Paperless, and the RAG index is a regenerable search cache rather than a second document store.
 
 **[Try the live demo](https://lucaperl.github.io/paperless-local-ai/demo/)** — an interactive browser-only preview using synthetic Paperless, Ollama and OCR data.
 
 ## Highlights
 
 - **Improved scan OCR with PaddleOCR** — PP-OCRv6 Medium is the quality-focused default, with Small and Tiny profiles when lower inference cost matters.
-- **Hybrid tagging** — compares new documents with reviewed Paperless documents, reuses a complete known leaf-tag set only behind a strict similarity/agreement gate, and sends cases without a confident observed-set match to the LLM with relevant reviewed examples and optional Tag Guidance.
-- **LLM direct** — lets a sufficiently capable local model choose tags directly from the Paperless taxonomy.
-- **Editable prompt composition** — System, Base classification and Tagging prompts are all editable. The Tagging prompt is sent only when the LLM actually has to choose tags.
-- **One LLM request per document** — title, type, date and sender/issuer are produced together; tags are included in the same request only on an LLM tag route.
-- **Optional Paperless-native correspondent review** — local resolution applies safe existing matches; the optional Suggestions integration can expose plausible new senders through Document Suggestions.
-- **Designed for CPU-only systems** — OCR, Hybrid-history work and LLM inference are serialized; heavyweight OCR/history/model runtimes are released after use.
-- **Control Center** — configure connections, workflow tags, correspondent matching (with a read-only live tester), OCR, prompts, model settings, tagging strategy, per-tag guidance, history health, Dry Run and configuration history from one UI.
-- **Optional Paperless RAG chat** — a multi-turn chat injected into Paperless itself, backed by a separate local SQLite index and a fixed one-embed + one-chat inference path.
+- **Structured local metadata automation** — title, document type, date and sender/issuer are extracted together; tags join the same LLM request only when the active tag route needs the model.
+- **Hybrid tagging for compact models** — reviewed Paperless documents can provide a confidence-gated exact tag-set reuse path, with an LLM fallback when the archive does not provide enough evidence.
+- **LLM direct tagging** — lets a sufficiently capable local model choose tags directly from the Paperless taxonomy.
+- **Conservative correspondent handling** — existing names are resolved locally; plausible new names can be exposed through the optional Paperless Suggestions bridge, but correspondents are never auto-created.
+- **Lightweight document chat** — persistent multi-chat RAG inside Paperless with document/tag/correspondent/type scopes, deterministic source links, live Paperless metadata, configurable prompt assembly and retrieval diagnostics.
+- **One embed + one chat model call per normal RAG turn** — no query-rewrite LLM, reranker LLM, refine chain, summarizer or agent loop on the normal path.
+- **Designed for modest CPU-only systems** — OCR, Hybrid-history work, metadata inference, RAG chat and index slices are serialized through one shared resource lock; heavyweight runtimes are released after use.
+- **Control Center** — one UI for connections, OCR, workflow settings, classification prompts/tagging, model settings, RAG prompts/retrieval/index administration, diagnostics, safe tests and configuration history.
 
 ## Why this architecture
 
-`paperless-local-ai` is built around three priorities: **OCR quality, practical local inference on modest hardware, and predictable automation inside Paperless.**
+`paperless-local-ai` is built around four priorities: **useful local AI, strong OCR, predictable Paperless integration and practical operation on modest hardware.**
 
-**Better OCR before classification.** Metadata extraction can only be as reliable as the text it receives. PP-OCRv6 Medium is the quality-focused default; Small and Tiny trade recognition quality for lower inference cost. HPI/OpenVINO accelerates the selected profile on CPU.
+**Useful local AI on small servers.** The project favors bounded, inspectable pipelines over maximum throughput. Only one heavyweight AI workload runs at a time, model residency is kept short, scientific/history helpers are disposable, and the RAG path avoids a separate vector service. This makes the stack practical on CPU-only home servers where RAM and sustained inference time matter more than benchmark concurrency.
 
-**Semantic metadata stays with the LLM.** Title, document type, date and sender/issuer benefit directly from document understanding, so they are produced together by the configured Ollama model.
+**Better OCR before downstream AI.** Metadata extraction and document retrieval can only be as reliable as the text they receive. PP-OCRv6 Medium is the quality-focused default; Small and Tiny trade recognition quality for lower inference cost. HPI/OpenVINO accelerates the selected profile on CPU.
 
-**Tags use an explicit Hybrid route by default.** Compact local models can understand what a document is about while still applying a personal filing taxonomy inconsistently. Hybrid tagging first compares the document with already reviewed Paperless documents. A complete reviewed leaf-tag set is reused only when the closest match is sufficiently similar and nearby reviewed examples agree strongly enough on that exact set. History considers only complete tag sets already present in reviewed history and never synthesizes a new combination. If no observed set passes the evidence gate, the LLM chooses the tags using the current Tag Guidance and relevant reviewed examples.
+**Structured automation instead of open-ended agents.** Metadata classification uses one structured request with constrained Paperless values where appropriate. Hybrid tagging can reuse a complete reviewed tag set only behind an explicit evidence gate; uncertain cases go to the LLM. Correspondent extraction is followed by conservative local resolution, and genuinely new correspondents are never auto-created.
 
-Paperless itself already contains an automatic classifier that learns from existing documents. The Hybrid route serves a different integration goal: it exposes an explicit evidence gate before reuse, can hand uncertain cases to the local LLM, and uses the same retrieved documents as examples for that fallback. It does **not** claim to be universally more accurate than Paperless' classifier. See [Tagging](docs/tagging.md#paperless-native-classifier-vs-hybrid-tagging) for the technical comparison.
+**Document chat stays lightweight.** The RAG feature is a first-class project capability but remains deliberately bounded. It keeps a regenerable SQLite index, performs exact local cosine retrieval, and uses exactly one query embedding request plus one chat-generation request for a normal turn. Full index work is sliced so the shared AI slot is released between batches, and an existing active index remains usable while a replacement index is built.
 
-**Sender extraction is followed by conservative local resolution.** The LLM returns the actual sender/issuer as free text. Normalized exact matches and deliberately strong unambiguous fuzzy matches can resolve to an existing Paperless correspondent. Other plausible names can be exposed through Document Suggestions when the optional bridge integration is configured; otherwise they remain unresolved for manual review.
-
-**Resource-aware execution.** The persistent `core-service` runtime is one Rust process. PaddleOCR/OpenVINO, on-demand Hybrid-history work and Ollama inference share one resource lock. The scientific Hybrid-history stack runs only in a disposable Python subprocess; OCR sessions and interactive history lookups can be reused briefly, while heavyweight subprocesses and the Ollama model are released after use.
+**Paperless remains authoritative.** OCR integrates into Paperless/OCRmyPDF, metadata is written back to Paperless, chat source links point to Paperless documents, and live source metadata is read from Paperless at chat time. `paperless-local-ai` does not become a second document management system.
 
 ## Reference performance
 
@@ -56,7 +60,7 @@ The **Context window** sets the maximum available context and affects RAM usage.
 
 ## RAM usage and tuning
 
-The main memory consumers are PaddleOCR during OCR and the Ollama model during metadata classification. Hybrid-history TF-IDF/scikit-learn state is loaded only in an on-demand subprocess and released again after use. Heavy OCR, history and LLM work is serialized through the shared resource lock.
+The main memory consumers are PaddleOCR and whichever Ollama model is active for metadata, embedding or chat. Hybrid-history TF-IDF/scikit-learn state is loaded only in an on-demand subprocess and released again after use. Heavy OCR, history, metadata, RAG chat and index work is serialized through the shared resource lock; the normal RAG path does not keep the embedding and chat models resident together.
 
 | Workload | Configuration | Measured peak |
 |---|---|---:|
@@ -71,24 +75,39 @@ If RAM is limited, lower **Maximum OCR image side** first for OCR pressure and r
 
 ## How it fits into Paperless
 
-During import, Paperless/OCRmyPDF decides whether a page needs OCR. Native-text pages are not sent to PaddleOCR. Pages requiring OCR are sent through the included OCRmyPDF plugin to the local PaddleOCR service, which returns OCRmyPDF-native `OcrElement` geometry.
+There are two complementary paths.
 
-After a document is added, a Paperless **Document Added** workflow assigns the classification queue tag. The metadata worker chooses the tag route, performs one structured Ollama request, resolves the extracted sender locally and writes validated metadata back to the same Paperless document.
+**Import and automation path**
 
-The configured review tag can have any name. It stays on the document until human review is complete; removing it makes the document eligible for trusted Hybrid history once queue/error tags are also gone. The recommended Paperless setup marks the chosen review tag as an **Inbox tag** so Paperless adds it automatically during import.
+```text
+Paperless import
+→ OCRmyPDF
+→ PaddleOCR when OCR is needed
+→ searchable Paperless archive/content
+→ Document Added workflow
+→ local metadata classification/tagging
+→ Paperless metadata
+→ human review
+```
 
-For an exclusive paperless-local-ai metadata workflow, set Paperless **Matching algorithm** to **None** for the content tags, document types, correspondents and technical workflow/review tags managed by paperless-local-ai. See [Paperless setup](docs/paperless-setup.md) for the exact setup.
+**Interactive document-chat path**
+
+```text
+Paperless chat panel
+→ one local query embedding
+→ exact retrieval from the PLAI SQLite index
+→ live Paperless metadata for selected sources
+→ one local chat generation
+→ answer + Paperless source links
+```
+
+The uploaded PDF stays Paperless' original. The RAG index contains only regenerable chunks/embeddings and minimal index metadata; Paperless content remains authoritative. Changing non-structural chat/retrieval settings does not rebuild the index. Structural embedding changes are saved separately from the active index signature and take effect only after an explicit atomic rebuild.
 
 <p align="center">
-  <img src="images/paperless-flow.svg" alt="paperless-local-ai workflow" width="65%">
+  <img src="images/paperless-flow.svg" alt="paperless-local-ai import and metadata workflow" width="65%">
 </p>
 
-Paperless stays the system of record:
-
-- the uploaded **original is preserved**;
-- OCRmyPDF creates the searchable archive/PDF-A representation;
-- Paperless stores OCR text and reviewed metadata;
-- Hybrid tagging reads reviewed Paperless documents and writes new metadata back to Paperless.
+The diagram above shows the import/metadata path. Document chat is a separate read/query path over the same Paperless archive.
 
 ## Tagging
 
@@ -132,27 +151,33 @@ Lowering **Minimum similarity** accepts more name variation. Lowering **Minimum 
 
 ## Control Center
 
-The Control Center configures:
+The Control Center configures both automation and document-chat administration:
 
 - Paperless and Ollama connections;
 - classification queue/error/review tags;
-- correspondent similarity/winner-margin thresholds and the read-only matching tester;
-- OCR language, PaddleOCR model, maximum OCR image side, retry schedule and recovery state;
+- correspondent matching thresholds and the read-only matching tester;
+- OCR language, PaddleOCR profile, image-size limit and retry/recovery behavior;
 - metadata Dry Run and worker timing;
-- model settings and all three classification prompt components;
-- **Hybrid tagging / LLM direct**, History health, supported History matching controls and per-tag Tag Guidance.
+- classification model settings plus System/Base/Tagging prompts;
+- Hybrid tagging / LLM direct, History health and per-tag guidance;
+- global document-chat defaults, System/source/answer prompt assembly, retrieval behavior and diagnostics;
+- embedding model/templates, chunking, batch/slice settings, sync interval and index Sync/Rebuild/Pause state.
 
-Prompts and model settings can be previewed and tested against an existing Paperless document without modifying that document. Saved configurations are versioned and can be restored.
+The actual document chat lives inside Paperless. The Control Center owns global/admin settings; per-chat overrides stay with each server-side conversation. Saved app/classification configurations are versioned and can be restored.
 
-## Optional Paperless RAG chat
+## Document chat
 
-When the Paperless UI integration is enabled, `paperless-local-ai` replaces the visible native Paperless chat control with its own multi-turn panel. Paperless itself is not patched. The panel supports the current document or the full archive, follow-up questions, deterministic Paperless source links and per-chat Ollama model/Thinking/context/Top-K/temperature/output settings.
+When the Paperless UI integration is enabled, `paperless-local-ai` injects its own multi-turn document chat into Paperless without patching Paperless source files. The feature is opt-in at deployment/UI level, but document chat is part of the supported project scope rather than an external add-on.
 
-The PLAI index is SQLite below the existing core data mount. A normal question performs **one Ollama embedding request and one Ollama chat request**; there is no LlamaIndex refine chain or extra query-rewrite/reranker LLM. The first build is explicit and later changes are synchronized incrementally. Browser → backend traffic stays same-origin through Paperless and is currently restricted to Paperless superusers. See [RAG chat](docs/rag-chat.md).
+Chats persist server-side and support scopes for the current document, all documents, tags, correspondents and document types. Per-chat controls include model/Thinking/context/generation settings plus retrieval overrides. Source links are deterministic Paperless links, and retrieved sources can include live Paperless metadata such as title, created date, correspondent and document type.
+
+The normal heavy-work path is fixed at **one Ollama `/api/embed` request and one Ollama `/api/chat` request**. Retrieval is exact cosine search against a local SQLite index; there is no LlamaIndex refine chain, reranker LLM, query-rewrite LLM or agent loop. Index rebuilds are explicit and sliced so OCR/metadata can use the same resource-constrained machine between embedding slices.
+
+See [RAG chat](docs/rag-chat.md) for prompt variables, retrieval/index controls, lifecycle behavior and the current defaults.
 
 ## Requirements
 
-Paperless-ngx · Ollama · Docker Compose or TrueNAS SCALE · linux/amd64
+Paperless-ngx · Ollama · Docker Compose or TrueNAS SCALE · linux/amd64 · GPU not required
 
 Tested reference: **Paperless-ngx 3.1.0 · OCRmyPDF 17.7.1 · TrueNAS SCALE 25.10.6 · Ollama 0.32.11**. See [Compatibility](docs/compatibility.md) for the exact tested scope.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,18 +1,23 @@
 # Roadmap
 
-Near-term ideas after the first external installations:
+`paperless-local-ai` now covers three first-class local-AI workflows around Paperless: scan OCR, metadata automation and lightweight document chat/RAG. Future work should keep the same **CPU-first, resource-bounded** design rather than expanding into a general AI platform.
 
-- system/status page in the Control Center (Paperless, Ollama, OCR, queue/tag readiness);
+Near-term ideas:
+
 - guided setup/check flow for first-time users;
-- compatibility CI against additional Paperless 3.x releases;
+- broader compatibility CI against additional Paperless 3.x releases;
+- permission-aware document-chat retrieval beyond the current superuser-only UI path;
 - validated ARM64 OCR image if Paddle support is practical;
-- optional OpenAI-compatible text inference backend without changing the CPU-first scope;
-- richer metrics without adding a database.
+- optional OpenAI-compatible text inference backend without changing the local/CPU-first scope;
+- better RAG quality/performance diagnostics that do not add hidden LLM calls to the normal one-embed + one-chat path;
+- richer metrics without adding another database/service.
 
 Out of scope for now:
 
-- bundled Ollama;
-- RAG/document chat;
+- bundling Paperless or Ollama;
+- requiring a dedicated vector database;
+- agent frameworks, autonomous tool loops or multi-stage LLM pipelines on the normal RAG path;
 - automatic creation of new correspondents;
 - cloud OCR/LLM dependencies by default;
-- vision-LLM OCR as the primary path.
+- vision-LLM OCR as the primary OCR path;
+- designs that require a GPU or assume multiple heavyweight models can stay resident concurrently.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,19 +1,26 @@
 # Architecture
 
-`paperless-local-ai` is a companion stack for Paperless-ngx. It improves scanned-page OCR through Paperless/OCRmyPDF plus a local PaddleOCR service and applies local metadata automation while keeping Paperless as the document system of record.
+`paperless-local-ai` is a CPU-first local-AI companion stack for Paperless-ngx. It adds three bounded capabilities around an existing Paperless installation: PaddleOCR-based scan OCR, structured metadata automation, and a lightweight document-chat/RAG path. Paperless stays the document system of record and Ollama stays external.
+
+The architecture intentionally targets modest CPU-only home-server hardware. Heavy OCR, scientific-history work, metadata inference, query embedding, chat generation and index embedding are coordinated instead of competing for memory and CPU.
 
 ## Design goals
 
-- **OCR quality before classification:** PP-OCRv6 Medium is the quality-focused default, with Small and Tiny profiles for lower inference cost.
-- **One structured LLM request per document:** title, document type, date and sender/issuer are extracted together; tags join that request only when the selected tag route needs an LLM decision.
-- **Hybrid tagging:** recurring reviewed patterns can reuse a complete known leaf-tag set behind a strict evidence gate; cases without a confident observed-set match use an LLM fallback with Tag Guidance and relevant reviewed examples.
-- **Local correspondent resolution:** the LLM extracts one free-text sender/issuer; Rust resolves safe existing matches or exposes a plausible new name through Paperless Document Suggestions.
-- **Bounded resource usage:** PaddleOCR/OpenVINO, Hybrid-history work and Ollama share one AI resource lock; heavyweight OCR/history subprocesses and the Ollama model are released after use.
-- **Lightweight RAG chat:** a disposable helper maintains a separate SQLite index and the normal chat path stays fixed at one query embedding plus one chat generation.
+- **Modest hardware is a first-class target:** no GPU is required; heavy AI work is serialized and heavyweight runtimes/models are released after use.
+- **OCR quality before downstream AI:** PP-OCRv6 Medium is the quality-focused default, with Small and Tiny profiles for lower inference cost.
+- **One structured metadata request per document:** title, document type, date and sender/issuer are extracted together; tags join that request only when the selected tag route needs an LLM decision.
+- **Hybrid tagging for compact models:** recurring reviewed patterns can reuse a complete known leaf-tag set behind a strict evidence gate; uncertain cases use an LLM fallback with Tag Guidance and relevant reviewed examples.
+- **Conservative correspondent resolution:** the LLM extracts one free-text sender/issuer; local Rust logic resolves safe existing matches or exposes a plausible new name through Paperless Document Suggestions.
+- **Lightweight RAG instead of an AI platform:** the chat uses a regenerable SQLite index, exact cosine retrieval, one embed + one chat call per normal turn, and no vector database, reranker LLM, refine chain or agent framework.
+- **Paperless remains authoritative:** originals, searchable archives, document content and metadata live in Paperless; PLAI caches/indexes are disposable application state.
 
 ## Pipeline
 
+The import/automation and interactive-chat paths share the same Paperless archive but have different lifecycles.
+
 ```text
+IMPORT / AUTOMATION
+
 Paperless import
       ↓
 Paperless parser / OCRmyPDF
@@ -23,45 +30,46 @@ OCR needed for a page?
   yes → OCRmyPDF rasterizes page
           ↓
         paperless-local-ai OCR plugin
-          ↓ authenticated HTTP
-        ocr-service
+          ↓
         PaddleOCR / PP-OCRv6
           ↓
         native OcrElement tree
           ↓
 OCRmyPDF searchable archive / PDF-A
+      ↓
 Paperless extracted content
       ↓
-Paperless Document Added workflow
+Document Added workflow
       ↓
-classification queue tag
+metadata queue
       ↓
-core-service metadata worker
-      ↓
-Tagging strategy
-  Hybrid tagging:
-    confident reviewed match → complete reviewed leaf-tag set fixed locally
-    otherwise                → LLM tag fallback + reviewed examples
-  LLM direct:
-    LLM decides tags directly
+Hybrid tagging or LLM direct
       ↓
 one structured LLM request
-  title · type · date · sender
-  + tags only when the LLM is responsible
       ↓
-local correspondent resolver
-  existing safe match → apply
-  plausible new name  → optional Paperless Suggestions integration
-  unreliable/empty    → leave empty
+local correspondent resolution
       ↓
-Paperless metadata + review
+Paperless metadata + human review
+
+
+INTERACTIVE DOCUMENT CHAT
+
+Paperless chat panel
       ↓
-human review removes configured review tag
+scope + current question + bounded prior context
       ↓
-eligible for trusted Hybrid history
+one Ollama query embedding
+      ↓
+exact cosine retrieval from /data/rag/rag.db
+      ↓
+optional adjacent chunks + live Paperless source metadata
+      ↓
+one Ollama chat generation
+      ↓
+answer + deterministic Paperless source links
 ```
 
-The uploaded PDF stays Paperless' original. OCR happens while Paperless consumes the document; `paperless-local-ai` does not maintain a separate OCR queue.
+The uploaded PDF stays Paperless' original. OCR happens while Paperless consumes the document. RAG indexing is independent, explicit/regenerable background work and never becomes a second authoritative archive.
 
 ## Services
 
@@ -78,11 +86,19 @@ The core image defaults to `/usr/local/bin/plai-core`. It retains `/app/core_ser
 
 ## RAG chat
 
-The optional RAG chat does not use Paperless' internal LLM index. `core-service` exposes secret-protected `/api/rag/*` job endpoints and launches `/app/rag_engine.py` only for an index/chat operation. The helper uses Paperless REST API v10, stores its regenerable SQLite index under `/data/rag`, performs exact cosine retrieval locally and exits after the job. The first rebuild uses a separate build database and atomically swaps it into place when complete, so an existing index remains available while rebuilding.
+Document chat is a supported project capability, but its implementation is intentionally small enough for resource-constrained CPU-only servers.
 
-The Paperless-side Django integration is same-origin and superuser-only. It is inserted after Paperless Authentication middleware, performs explicit CSRF validation for writes and forwards only a fixed path allow-list using an internal secret generated in the shared integration mount. The browser never receives that secret or the Paperless API token.
+`core-service` exposes secret-protected `/api/rag/*` job endpoints and launches `/app/rag_engine.py` only for index/chat work. The helper uses Paperless REST API v10, stores a regenerable SQLite index under `/data/rag`, performs exact cosine retrieval locally and exits after the job. No additional long-running RAG service or vector database is used.
 
-For a normal chat turn, the helper holds the existing AI lock across one `/api/embed` call, exact retrieval and one streaming `/api/chat` call. Query-side embeddings use the Qwen3-Embedding retrieval instruction while indexed document chunks remain unprefixed. Both interactive Ollama requests use `keep_alive=0`. Index rebuilds embed in bounded slices, keep the embedding model warm only within a slice and release the AI lock between slices. See [RAG chat](rag-chat.md).
+For a normal turn, the helper uses the shared AI lock across one Ollama `/api/embed` request, local retrieval/prompt assembly and one streaming `/api/chat` request. Query-side embeddings use the configured query template; indexed chunks use the configured document template. Both interactive requests use `keep_alive=0`. This fixed path deliberately excludes query-rewrite, reranker, refine, summarizer and agent LLM calls.
+
+Retrieved chunks can be expanded with adjacent chunks without another model call. Before prompt assembly, source metadata is refreshed from Paperless. The default source template supplies source number, title, created date, correspondent, document type, document ID and retrieved text; the Control Center exposes additional Paperless document fields as optional template variables. Live metadata lookup adds Paperless HTTP requests, not extra Ollama requests.
+
+The first full index build is explicit. `rag.db.build` keeps completed rebuild work separate from the active `rag.db`, and activation is atomic. Structural embedding changes mark the configured index as requiring a rebuild while the active index continues serving queries. Rebuild embedding is split into bounded slices and releases the shared AI slot between slices so OCR and metadata are not starved. Interrupted rebuild staging is retained and reconciled to a paused state for explicit resume.
+
+The Paperless-side integration is same-origin and currently superuser-only. It performs CSRF validation for writes and forwards only a fixed allow-list using an internal relay secret. The browser never receives that secret or the Paperless API token.
+
+See [RAG chat](rag-chat.md).
 
 ## OCRmyPDF integration
 
@@ -100,7 +116,7 @@ Transient worker/service failures use bounded automatic retries. Deterministic c
 
 ## Shared AI resource lock
 
-OCR, Hybrid-history work and metadata inference share one exclusive file lock at `/coordination/ai.lock`. This prevents Paddle/OpenVINO, the scientific history helper and Ollama from performing heavy work concurrently. Automatic metadata routing shuts the history helper down before the Ollama request starts, and the core metadata worker unloads the configured Ollama model before leaving the AI transaction. Heavy resources are therefore released immediately when their work completes, independently of the lightweight unified core lifecycle. After a complete metadata batch or explicit History refresh, the core schedules a clean container recycle only after a fixed five-minute quiet period. New metadata work cancels the pending recycle, and Suggestion Bridge classification activity during the grace period postpones it. This keeps the Control Center and Suggestion Bridge available for normal follow-up requests while still allowing the existing `restart: unless-stopped` policy to start a fresh core cgroup after genuine inactivity, clearing file cache accumulated by the on-demand scientific helper and heavy Rust code paths while preserving all persistent state on mounted storage.
+OCR, Hybrid-history work, metadata inference, RAG query/chat inference and RAG index slices share one exclusive file lock at `/coordination/ai.lock`. This prevents Paddle/OpenVINO, the scientific history helper and Ollama from performing heavy work concurrently. Automatic metadata routing shuts the history helper down before the Ollama request starts, and the core metadata worker unloads the configured Ollama model before leaving the AI transaction. Heavy resources are therefore released immediately when their work completes, independently of the lightweight unified core lifecycle. After a complete metadata batch or explicit History refresh, the core schedules a clean container recycle only after a fixed five-minute quiet period. New metadata work cancels the pending recycle, and Suggestion Bridge classification activity during the grace period postpones it. This keeps the Control Center and Suggestion Bridge available for normal follow-up requests while still allowing the existing `restart: unless-stopped` policy to start a fresh core cgroup after genuine inactivity, clearing file cache accumulated by the on-demand scientific helper and heavy Rust code paths while preserving all persistent state on mounted storage.
 
 ## Structured metadata request
 
@@ -186,7 +202,7 @@ Persistent state lives below one `APP_DATA_DIR`:
 
 ```text
 config/        app and classification configuration/history
-core/          results, review records, history cache and regenerable RAG index
+core/          results, review records, history cache, server-side chats and regenerable RAG index
 ocr/           PaddleX/OpenVINO cache and OCR runtime state
 coordination/  shared ai.lock + OCR recovery + history broker socket
 integration/   generated OCRmyPDF plugin consumed by Paperless

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,8 @@
 # Configuration
 
-The **Control Center** is the main interface for `paperless-local-ai` configuration, testing and configuration history.
+The **Control Center** is the main interface for `paperless-local-ai` configuration, testing and configuration history. It covers both the import/metadata pipeline and global document-chat/RAG administration.
+
+Defaults are intentionally conservative for modest CPU-only hardware. The project serializes heavyweight OCR/history/embedding/chat/model work through one shared AI slot; increasing context, batch or image-size settings should be treated as a resource trade-off rather than a free speed increase.
 
 ## Recommended first-time setup order
 
@@ -11,10 +13,11 @@ The **Control Center** is the main interface for `paperless-local-ai` configurat
 5. Complete the matching [Paperless setup](paperless-setup.md), including the review-tag lifecycle, Paperless matching settings, metadata workflow and OCRmyPDF integration.
 6. **App Settings → Runtime** — leave metadata writes enabled or temporarily use Dry Run for read-only metadata testing.
 7. **Classification → Tagging** — choose Hybrid tagging or LLM direct and optionally describe ambiguous tags.
-8. **Classification → Prompt** — review the editable System, Base classification and Tagging prompts.
+8. **Classification → Prompt / Settings** — review prompts, model and context/document limits.
 9. **Classification → Test** — run a safe preview/model test against an existing document.
+10. **Document Chat** — if document chat is wanted, review the chat/retrieval/embedding defaults, enable the Paperless UI integration and start the first RAG index build explicitly.
 
-Saved app/classification configurations are versioned and can be restored from the UI.
+Saved app/classification configurations are versioned and can be restored from the UI. RAG configuration is stored separately from classification settings so chat/index tuning cannot silently change metadata behavior.
 
 ## Connections
 
@@ -82,7 +85,7 @@ Additional memory reference points:
 | Metadata | qwen3.5:4b Q4_K_M · 8k context | ~3.8 GiB |
 | Metadata | qwen3.5:4b Q4_K_M · 16k context | ~4.2 GiB |
 
-PaddleOCR, on-demand Hybrid-history work and Ollama inference are serialized through the shared AI resource lock. The scientific history helper is released before automatic/model-test Ollama inference, so its temporary memory does not remain resident through the LLM phase.
+PaddleOCR, on-demand Hybrid-history work, metadata Ollama inference, RAG query/chat inference and RAG index slices are serialized through the shared AI resource lock. The scientific history helper is released before automatic/model-test Ollama inference, so its temporary memory does not remain resident through the LLM phase.
 
 If RAM is limited, lower **Maximum OCR image side** first when OCR is the problem and reduce the Classification **Context window** when the LLM is the problem. `OCR_MEMORY_LIMIT` is a deployment safety ceiling; raising it does not reduce memory use.
 
@@ -194,6 +197,57 @@ New correspondents are never auto-created. The optional Paperless Suggestions in
 ## Ollama lifecycle
 
 The metadata worker uses the configured model for the structured request and unloads it before releasing the shared AI transaction. `keep_alive` is still available as an Ollama request parameter, while explicit unload is the standard end-of-document behavior.
+
+## Document chat and RAG
+
+Document-chat administration lives under **Document Chat** in the Control Center. The actual conversations live inside Paperless.
+
+### Chat and prompt assembly
+
+Global defaults include the chat model, Thinking mode, context size, temperature, output limit and the number of previous user/assistant messages sent to the answer model. The default answer-history depth is **8 messages**.
+
+The RAG System prompt, **Retrieved source template** and **Answer prompt template** are editable. Source-template metadata is read live from Paperless for each chat turn. The default source block includes title, created date, correspondent, document type and document ID plus the retrieved chunk. Additional variables expose tags, storage path, page count, custom fields and other Paperless document metadata; very large values such as full content/raw JSON are available for expert use but are not part of the default template.
+
+Changing source/answer prompts or other non-structural chat settings does **not** require an index rebuild.
+
+### Retrieval
+
+The default retrieval-history mode uses **user messages only** with **3 previous user turns**. This affects the embedding query and is separate from the answer model's 8-message conversation-history window.
+
+Other supported controls include:
+
+- minimum cosine similarity (disabled by default);
+- maximum primary chunks per document (unlimited by default);
+- adjacent chunk expansion (`Off`, `±1`, `±2`, `±3`; default `Off`);
+- optional document-context budget percentage (default `Auto`);
+- retrieval diagnostics (default `Off`).
+
+Adjacent chunk expansion is local and does not add another model call. Diagnostics can show the effective retrieval query, selected scores/ordinals/neighbors and prompt-budget information without adding model inference.
+
+### Embedding and index
+
+Current defaults:
+
+| Setting | Default |
+|---|---|
+| Embedding model | `qwen3-embedding:4b-q4_K_M` |
+| Document embedding template | `{{CHUNK}}` |
+| Chunk target | `2000` characters |
+| Chunk overlap | `400` characters |
+| Embedding batch size | `1` |
+| Embedding slice size | `16` chunks |
+| Sync interval | `900` seconds |
+| Embedding dimensions | model native |
+| Query/document truncation | enabled |
+| Embedding context override | Auto |
+
+The small batch default is intentional for the CPU-only reference design. Larger batches can increase memory pressure or perform worse on limited CPUs; benchmark before changing them.
+
+Structural changes such as the embedding model, document embedding template, dimensions, document truncation/context behavior or chunk geometry do not replace the active index immediately. They mark the configured state as **rebuild required**. The active index remains usable until an explicit rebuild finishes and is atomically activated.
+
+Runtime-only/query-side settings can change without invalidating the active index. Full rebuilds are sliced and release the shared AI lock between slices. On CPU-only hardware, a complete initial build can take hours; it is therefore never started automatically just because the app was installed or updated.
+
+See [RAG chat](rag-chat.md) for the end-to-end behavior.
 
 ## Language
 

--- a/docs/control-center.md
+++ b/docs/control-center.md
@@ -1,6 +1,8 @@
 # Control Center
 
-The Control Center is the browser UI for connections, workflow tags, OCR, classification prompts/settings, tagging strategy, diagnostics, safe tests and configuration history.
+The Control Center is the administration UI for the whole `paperless-local-ai` stack: connections, OCR, metadata automation, tagging/history, document-chat defaults, RAG/index settings, diagnostics, safe tests and configuration history.
+
+It deliberately separates **global/admin settings** from the actual document chat. Users chat inside Paperless; the Control Center configures how that chat behaves and how its local index is maintained.
 
 ## Where settings live
 
@@ -8,18 +10,32 @@ The Control Center is the browser UI for connections, workflow tags, OCR, classi
 |---|---|
 | **Overview** | connection/OCR/tagging status, pipeline and current key settings |
 | **App Settings** | Paperless/Ollama connections, workflow/review tags, correspondent matching + read-only tester, OCR, Dry Run and worker timing |
-| **Classification → Test** | read-only prompt preview and read-only real model test against an existing Paperless document |
+| **Classification → Test** | prompt preview and read-only real model test against an existing Paperless document |
 | **Classification → Tagging** | Hybrid/LLM-direct strategy, reviewed-history health and Tag Guidance |
 | **Classification → Prompt** | editable System, Base classification and Tagging prompts |
-| **Classification → Settings** | Ollama model, context/document limits and advanced model parameters |
-| **History** tabs | separate saved versions for App settings and Classification settings |
+| **Classification → Settings** | classification Ollama model, context/document limits and advanced model parameters |
+| **Document Chat → Chat & prompts** | global chat defaults, conversation-history depth, RAG System prompt, retrieved-source template and final answer prompt template |
+| **Document Chat → Retrieval** | retrieval-history behavior, previous-user-turn window, similarity/document caps, adjacent chunks, context budget and diagnostics defaults |
+| **Document Chat → Embedding & index** | embedding model/templates, dimensions/context/truncation, chunking, batch/slice size and sync interval |
+| **Document Chat → Index status** | Sync, Rebuild, Pause/Resume and active/rebuild-required state |
+| **History** tabs | saved versions for App settings and Classification settings |
 
-The configured review tag can have any name. Paperless-side setup still matters: the review-tag lifecycle, matching algorithms, workflow and OCRmyPDF integration are documented in [Paperless setup](paperless-setup.md).
+The configured review tag can have any name. Paperless-side setup still matters: the review-tag lifecycle, matching algorithms, workflow, OCRmyPDF plugin and optional same-origin UI integration are documented in [Paperless setup](paperless-setup.md).
 
-**Test correspondent matching** compares a typed sender name with the current Paperless correspondents using the unsaved Matching thresholds. It shows the top three candidates and decision gates without calling Ollama or changing Paperless. Both thresholds can be configured across the complete `0-100` range; short plausible sender names use the same fuzzy ranking as longer names.
+## CPU-first behavior
 
-**Preview prompts** does not call Ollama. **Run model test** calls Ollama but does not modify the selected Paperless document or persist a correspondent suggestion. **Dry Run** is optional and controls automatic metadata write-back; it does not disable Paperless import/OCR.
+The Control Center exposes performance-sensitive RAG/OCR/LLM controls, but the default architecture still assumes one modest machine. OCR, Hybrid-history work, metadata inference, RAG chat and index embedding share one AI resource lock. A waiting chat reports the current heavy-work owner instead of starting a second model workload.
 
-Opening the Control Center reads cached History health plus a lightweight Paperless source signature; it does not load NumPy/SciPy/scikit-learn or rebuild the TF-IDF index. Hybrid preview/refresh can start the on-demand history helper, which is released after a short interactive idle period; a model test shuts it down before Ollama starts.
+Increasing embedding batch size, context size, output limits or OCR image size can raise latency or RAM pressure. Defaults favor predictable operation on CPU-only hardware rather than maximum concurrent throughput.
 
-See [Configuration](configuration.md) for the full field-by-field behavior and reference performance/resource guidance.
+## Safe testing
+
+**Test correspondent matching** compares a typed sender name with current Paperless correspondents using the unsaved Matching thresholds. It does not call Ollama or change Paperless.
+
+**Preview prompts** does not call Ollama. **Run model test** calls Ollama but does not modify the selected Paperless document or persist a correspondent suggestion. **Dry Run** controls automatic metadata write-back; it does not disable Paperless import/OCR.
+
+RAG prompt previews are synthetic and do not query the private archive. Retrieval diagnostics are generated from a real chat turn only when enabled and do not add an extra model call.
+
+Opening the Control Center reads cached History health plus a lightweight Paperless source signature; it does not keep NumPy/SciPy/scikit-learn resident. Hybrid preview/refresh can start the on-demand history helper, which is released again before Ollama work.
+
+See [Configuration](configuration.md) for field behavior, [RAG chat](rag-chat.md) for the document-chat pipeline, and [Troubleshooting](troubleshooting.md) for runtime symptoms.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,8 @@ You need:
 - a running Ollama instance reachable from the app containers;
 - Docker Compose v2;
 - a Paperless API token;
-- an installed Ollama model (`qwen3.5:4b` is the default);
+- an installed Ollama chat/classification model (`qwen3.5:4b` is the default);
+- if document chat is used, an installed embedding model (`qwen3-embedding:4b-q4_K_M` is the default);
 - permission to add the OCRmyPDF plugin mount/environment to Paperless.
 
 Fresh installations use English OCR and English prompt defaults. OCR language and the three editable prompt components can be changed independently in the Control Center.
@@ -141,7 +142,24 @@ Follow [Paperless setup](paperless-setup.md).
 
 Only the metadata/review workflow tags are required by the app. OCR runs directly during Paperless import through OCRmyPDF.
 
-## 7. Verify
+## 7. Optional: enable document chat
+
+Document chat is part of the supported project scope but remains opt-in.
+
+Complete the **Optional Paperless UI integration and RAG chat** section in [Paperless setup](paperless-setup.md), restart Paperless so the integration package is loaded, then enable the Paperless UI integration from the Control Center.
+
+Under **Control Center → Document Chat**:
+
+1. review the chat/retrieval defaults;
+2. verify the embedding model exists in Ollama;
+3. keep the CPU-first defaults unless you have benchmarked your hardware;
+4. start the first index build explicitly under **Index status**.
+
+Paperless' native embedding backend is not required. The PLAI index is local/regenerable and a normal chat turn uses one embedding request plus one chat request.
+
+On CPU-only hardware, the first full index build can take hours for a non-trivial archive. It is sliced and releases the shared AI slot between slices so OCR/metadata work is not permanently blocked.
+
+## 8. Verify
 
 Run:
 

--- a/docs/paperless-setup.md
+++ b/docs/paperless-setup.md
@@ -114,7 +114,7 @@ After Paperless has restarted with these values, the Control Center verifies tha
 
 The configured Control Center URL must be reachable from **inside the Paperless container** because the authenticated same-origin relay forwards RAG requests to `core-service` through that URL. RAG writes require the normal Paperless CSRF token and are currently restricted to Paperless superusers. The browser never receives the Paperless API token or the internal relay secret.
 
-The first RAG index build is started explicitly from the injected chat settings. Paperless' native embedding backend is not required for PLAI RAG. See [RAG chat](rag-chat.md).
+The first PLAI RAG index build is started explicitly from **Control Center → Document Chat → Index status**. Paperless' native embedding backend is not required for PLAI RAG. The Paperless chat panel is for conversations/per-chat settings; global prompt, retrieval, embedding and index administration stays in the Control Center. See [RAG chat](rag-chat.md).
 
 The plugin is verified against OCRmyPDF **17.7.1** in Paperless-ngx **3.1.0**.
 

--- a/docs/rag-chat.md
+++ b/docs/rag-chat.md
@@ -1,62 +1,118 @@
-# Paperless RAG chat
+# Paperless document chat / RAG
 
-`paperless-local-ai` can provide an optional lightweight RAG chat directly inside the Paperless-ngx web interface. Paperless remains unmodified and remains the document system of record.
+`paperless-local-ai` provides a deliberately lightweight local document-chat path directly inside the Paperless-ngx web interface. It is a first-class project capability, while remaining opt-in for deployments that only want OCR/metadata automation.
+
+The design target is the same as the rest of the project: **useful local AI on modest CPU-only hardware**. RAG therefore reuses the existing core service and shared AI lock, stores vectors in SQLite, and keeps the normal turn to one embedding request plus one chat-generation request.
+
+Paperless remains unmodified and remains the document system of record.
 
 ## UI integration
 
-When the optional Paperless UI integration is enabled, the integration injects a same-origin JavaScript asset into Paperless. After a successful authenticated PLAI bootstrap, it hides Paperless' native AI chat control and inserts the PLAI chat control in the same navbar area. The native component is hidden rather than removed. If PLAI cannot initialize after a future Paperless frontend change, the integration fails open and leaves Paperless' own UI available.
+When the Paperless UI integration is enabled, a same-origin JavaScript asset injects the PLAI chat control into Paperless. The native Paperless chat component is hidden only after a successful PLAI bootstrap; if PLAI cannot initialize after a future Paperless frontend change, the integration fails open and leaves Paperless usable.
 
-The chat panel is isolated in Shadow DOM. Keyboard events are stopped at that boundary after PLAI controls handle them, so typing in chat, model, scope or settings fields does not trigger Paperless' global keyboard shortcuts. The same integration keeps the existing Settings shortcut to the Control Center; there is no second chat UI in the Control Center and index controls are kept in the chat panel instead of linking to a duplicate Control Center index page.
+The chat panel is isolated in Shadow DOM. Keyboard events are stopped at that boundary after PLAI controls handle them, so typing in chat/model/scope/settings fields does not trigger Paperless global shortcuts.
 
-Browser requests stay on the Paperless origin below `/_plai/`. The browser does not connect directly to the Control Center port or Ollama. Paperless authenticates the browser session, requires a superuser for the initial implementation, applies CSRF protection to writes and relays only a fixed allow-list of RAG requests to `core-service`. The relay authenticates to the core with an internal random secret stored in the shared integration directory and never exposed to browser JavaScript.
+Browser requests stay on the Paperless origin below `/_plai/`. Paperless authenticates the browser session, requires a superuser for the current implementation, applies CSRF protection to writes and relays only a fixed allow-list of requests to `core-service`. The relay uses an internal random secret stored in the shared integration directory. Neither that secret nor the Paperless API token is exposed to browser JavaScript.
+
+Global RAG/index administration lives in the **Control Center → Document Chat** page. The Paperless chat panel contains conversation and per-chat controls, not a second copy of the index administration UI.
 
 ## Chat behavior
 
 The panel supports:
 
-- persistent server-side conversations that can be resumed from another browser/device;
-- new/open/rename/delete chat history without an extra LLM title-generation call;
-- scope `Current document`, `All documents`, `Tag`, `Correspondent` or `Document type`; tag/correspondent/document-type values use a type-ahead combobox backed by Paperless IDs, and Current document follows Paperless SPA navigation while the panel stays open;
+- persistent server-side conversations that can be opened from another browser/device;
+- new/open/rename/delete chat history without an LLM title-generation call;
+- scopes `Current document`, `All documents`, `Tag`, `Correspondent` and `Document type`;
+- type-ahead Paperless scope selection by stable IDs;
+- Current-document scope that follows Paperless SPA navigation while the panel remains open;
 - clickable Paperless source documents;
 - installed Ollama model discovery plus free model entry;
 - Thinking `Auto`, `Off` or `On`;
-- context size;
-- retrieval Top-K;
-- temperature;
-- maximum output tokens;
-- incremental answer/status updates and a Stop action;
-- explicit index Sync, Rebuild and Pause/Resume controls;
-- editable embedding model, chunk target/overlap, embedding batch/slice sizes and sync interval in the index settings UI.
+- context size, temperature and maximum output tokens;
+- retrieval Top-K plus per-chat overrides for conversation history, adjacent chunks, document-context budget and retrieval diagnostics;
+- incremental answer/status updates, explicit Stop and smart auto-scroll.
 
-Conversation history is stored persistently below `/data/chat` and is keyed by the authenticated Paperless user ID supplied by the trusted same-origin relay. Conversation files are protected by a server-side file lock; no chat content is stored in browser session storage. The browser remembers only the currently selected server-side conversation ID. The backend still sends only a bounded recent history to the model and never adds an LLM summarization/title call.
+Conversation history is stored below `/data/chat` and keyed by the authenticated Paperless user ID supplied by the trusted relay. No chat content is stored in browser session storage. The browser remembers only the current server-side conversation ID.
 
-## RAG pipeline
+Closing or navigating away from a chat does not implicitly cancel a running generation. **Stop** is the explicit cancellation action.
 
-A normal chat turn has a deliberately fixed heavy-work shape:
+## Normal RAG pipeline
+
+A normal chat turn has a fixed heavy-work shape:
 
 ```text
-question
+question + bounded retrieval history
   ↓
-1 × Ollama /api/embed (Qwen query-side retrieval instruction)
+1 × Ollama /api/embed
   ↓
-exact cosine retrieval from the PLAI index
+exact cosine retrieval from the PLAI SQLite index
   ↓
-Top-K untrusted document excerpts
+optional adjacent chunks (local only)
+  ↓
+live Paperless metadata for selected source documents
+  ↓
+prompt assembly / context budgeting
   ↓
 1 × Ollama /api/chat
   ↓
 answer + deterministic Paperless source links
 ```
 
-There is no LlamaIndex response-refine chain, query-rewrite LLM, reranker LLM or agent loop. Retrieved document text is explicitly framed as untrusted data. Archive-specific claims should be based on the supplied excerpts.
+There is no query-rewrite LLM, reranker LLM, response-refine chain, summarizer or agent loop on the normal path.
 
-The browser receives generation progress by polling a small same-origin job-status endpoint while the helper consumes Ollama's streaming response. This keeps the Rust core dependency graph small while still updating the visible answer during generation.
+Paperless metadata lookups and adjacent-chunk expansion are local/API work and do not add model calls.
 
-Embedding and chat inference use the existing `/coordination/ai.lock`. OCR, metadata classification, RAG chat and RAG-index slices remain serialized. `/coordination/ai-status.json` is informational metadata only and lets a waiting chat explain whether OCR, metadata, another chat or index embedding currently owns the slot; `ai.lock` remains the only synchronization primitive. Both interactive embedding and chat requests use `keep_alive=0`, so their models are released as the request completes before the AI transaction ends. Full-index embedding work is split into bounded slices; the embedding model is reused within a slice, unloaded before the AI lock is released, and other OCR/metadata work can acquire the slot between slices.
+## Prompt assembly and source metadata
 
-## Index
+Three global prompt layers are configurable under **Control Center → Document Chat**:
 
-The RAG index is independent of Paperless' native LLM index. Paperless' embedding backend can therefore remain empty when PLAI RAG is used.
+- **System prompt** — global answer behavior, time/user/search-scope variables and untrusted-document framing;
+- **Retrieved source template** — rendered once per selected source;
+- **Answer prompt template** — wraps the rendered source blocks plus the current question.
+
+The default source template is:
+
+```text
+[Source {{SOURCE_NUMBER}}]
+Title: {{DOCUMENT_TITLE}}
+Created: {{DOCUMENT_CREATED}}
+Correspondent: {{DOCUMENT_CORRESPONDENT}}
+Document type: {{DOCUMENT_TYPE}}
+Document ID: {{DOCUMENT_ID}}
+
+{{CHUNK}}
+```
+
+Source metadata is refreshed from Paperless at chat time, so metadata edits do not require a RAG rebuild. Correspondent/document-type/tag/storage-path names are resolved from Paperless IDs. If supplementary metadata lookup fails, retrieval still has indexed document identity/text and fails open rather than making metadata resolution a second AI dependency.
+
+The variable catalog also exposes fields such as tags, storage path, page count, MIME type, notes, custom fields, versions, owner/permissions and raw/metadata JSON. `DOCUMENT_CONTENT` and `DOCUMENT_RAW_JSON` can be very large and are intended for expert templates only.
+
+Retrieved document text is untrusted data. The default System prompt instructs the model not to follow instructions contained inside source documents.
+
+## Retrieval controls
+
+Global defaults are:
+
+| Setting | Default |
+|---|---|
+| Retrieval Top-K | `5` |
+| Retrieval history mode | user messages only |
+| Previous user turns for retrieval | `3` |
+| Minimum similarity | disabled |
+| Max primary chunks per document | unlimited |
+| Adjacent chunks | Off |
+| Document context budget | Auto |
+| Retrieval diagnostics | Off |
+
+Retrieval history is separate from answer-model conversation history. The answer model receives up to **8 previous user/assistant messages** by default, while the embedding query uses the current question plus up to **3 previous user turns**.
+
+Adjacent chunks add neighboring text around a primary similarity hit after ranking. They do not change Top-K ranking and do not cause another embedding/chat request.
+
+Diagnostics can persist the effective retrieval query, similarity scores, selected chunk ordinals/neighbors, rendered source previews and prompt-budget statistics. They are disabled by default and do not add inference.
+
+## Index and current defaults
+
+The PLAI RAG index is independent of Paperless' native LLM index. Paperless' embedding backend can remain empty when PLAI RAG is used.
 
 Persistent state lives below:
 
@@ -64,45 +120,53 @@ Persistent state lives below:
 /data/rag/
 ```
 
-The active index is `rag.db`. A full rebuild uses `rag.db.build`, leaving an existing active index available until the rebuilt database is atomically activated. The SQLite store contains regenerable document chunks, float32 embedding vectors and minimal Paperless metadata. Paperless content remains authoritative.
+`rag.db` is the active index. `rag.db.build` is a staging database for a full rebuild. The SQLite store contains regenerable document chunks, float32 embedding vectors and minimal index metadata; Paperless remains authoritative.
 
-Default index settings live in `/config/rag-config.json`:
+Current defaults:
 
-```text
-embedding model     qwen3-embedding:4b-q4_K_M
-chunk target        4000 characters
-chunk overlap       800 characters
-embedding batch     16 chunks
-embedding slice     64 chunks
-sync interval       900 seconds
-```
+| Setting | Default |
+|---|---|
+| Embedding model | `qwen3-embedding:4b-q4_K_M` |
+| Query template | Qwen3-Embedding retrieval instruction |
+| Document template | `{{CHUNK}}` |
+| Chunk target | `2000` characters |
+| Chunk overlap | `400` characters |
+| Embedding batch size | `1` |
+| Embedding slice size | `16` chunks |
+| Sync interval | `900` seconds |
+| Query/document truncation | enabled |
+| Embedding dimensions/context override | model default / Auto |
 
-Chat defaults are `qwen3.5:4b`, 8192 context, 512 output tokens, temperature `0.1`, Thinking off and Top-K `5`. Per-chat settings do not alter metadata-classification settings.
+Chat defaults are `qwen3.5:4b`, 8192 context, 512 output tokens, temperature `0.1`, Thinking off, Top-K `5` and 8 previous answer-history messages.
 
-The first full index build is explicit. PLAI never starts an expensive initial rebuild merely because the software was updated. Once an active index exists, a lightweight periodic sync checks for new/modified documents and reconciles deletions. The chat panel can edit the embedding model, chunk target/overlap, embedding batch/slice sizes and sync interval with the same validation bounds as the indexer. Index settings are split conceptually into the active index signature and configured runtime/rebuild settings: changing the embedding model or chunk target/overlap marks the active index as requiring an explicit rebuild, while batch size, slice size and sync interval can change without invalidating the active index.
+The first full index build is explicit. PLAI never starts an expensive initial rebuild merely because the software was installed or updated. Once an active index exists, periodic sync checks for new/modified documents and reconciles deletions.
 
-A rebuild snapshots target document IDs/modified timestamps into the build database and records completed documents. An interrupted rebuild can therefore resume without discarding completed document versions. A document interrupted during its embedding step is retried as a unit. If the core/container restarts while a rebuild staging database exists, startup reconciles stale running state to `Paused`; the staging database is kept and the user explicitly resumes the rebuild instead of it restarting heavy AI work automatically.
+Structural embedding changes are tracked separately from the active index signature. The active index remains usable until an explicit rebuild completes and atomically replaces it. Batch size, slice size, sync interval and query-side/runtime controls do not invalidate the active corpus vectors.
+
+A rebuild snapshots target document versions and records completed documents in the staging database. Interrupted rebuilds retain completed work. If the core restarts with an interrupted staging index, startup reconciles it to **Paused** and requires explicit Resume rather than automatically resuming heavy work.
+
+## Resource behavior on modest hardware
+
+OCR, metadata classification, Hybrid-history work, RAG chat and index embedding share `/coordination/ai.lock`.
+
+A waiting chat can report which heavy workload currently owns the slot. `/coordination/ai-status.json` is display metadata only; the file lock is the synchronization primitive.
+
+Interactive embedding and chat requests use `keep_alive=0`, so each model is released when its request completes. Full-index work is split into bounded slices; the embedding model is reused only within the slice and unloaded before the lock is released.
+
+The default embedding batch size of `1` and slice size of `16` favor predictable CPU-only behavior. On limited CPUs a full index build should be expected to take substantially longer than on GPU hardware, potentially hours for a non-trivial archive. This is why initial/rebuild work is explicit, resumable and non-destructive to the active index.
 
 ## Paperless AI settings
 
-The native Paperless RAG index is not required. When the correspondent Suggestions bridge is used, the intended Paperless AI arrangement is:
+Paperless' native embedding/RAG backend is not required.
 
-```text
-Enable AI features:        on
-LLM backend:               ollama
-LLM model:                 paperless-correspondent-bridge
-LLM endpoint:              http://<bridge-host>:30149
-LLM embedding backend:     none / empty
-LLM embedding model:       empty
-LLM embedding endpoint:    empty
-```
+If the optional correspondent Suggestions bridge is used, Paperless AI can point only its LLM/suggestions path at the bridge while leaving embedding settings empty. The bridge does not provide general chat; PLAI document chat uses the separate same-origin RAG endpoints.
 
-Paperless uses the bridge only for the narrow Document Suggestions compatibility path. The injected PLAI chat calls the separate PLAI RAG endpoints.
+See [Paperless setup](paperless-setup.md) for the current bridge arrangement.
 
-## Upgrade boundary
+## Compatibility boundary
 
-The RAG indexer reads Paperless through REST API version 10 and does not depend on Paperless' Python RAG classes or native vector-store schema. Existing non-RAG metadata integration keeps its prior API behavior so adding RAG does not broaden that compatibility boundary.
+The indexer reads Paperless through REST API version 10 and does not depend on Paperless' internal Python RAG classes or vector-store schema.
 
-The frontend integration primarily looks for Paperless' `chatDropdown` control. If that element changes, it falls back to the neighboring toast area and finally to a floating button. The chat panel itself is isolated from Paperless component CSS.
+The frontend integration primarily looks for Paperless' `chatDropdown` area and has fallback placement. A Paperless frontend upgrade can therefore affect placement, but it does not replace the PLAI RAG backend. Restart Paperless after updating the integration package so Django reloads the current middleware/assets.
 
-Paperless upgrades can therefore affect placement of the injected control, but they do not patch or replace the PLAI RAG implementation. Restart Paperless after updating the integration package so Django reloads the current middleware and assets.
+See [Compatibility](compatibility.md) before broadening version claims.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -39,6 +39,27 @@ For the OCR service, verify:
 - PP-OCRv6 Tiny is rejected with Japanese;
 - no unexpected model download occurs after a populated persistent cache.
 
+## RAG regression contract
+
+For meaningful document-chat/RAG changes, verify:
+
+- the normal answer path performs exactly one Ollama `/api/embed` request and one `/api/chat` request;
+- query history and answer-model conversation history remain separately bounded;
+- scope validation covers current document, all documents, tag, correspondent and document type;
+- Current-document scope follows Paperless SPA navigation;
+- source links point to the expected Paperless documents;
+- retrieved document content remains framed as untrusted data;
+- live source metadata resolution cannot turn a missing relation into a second AI dependency;
+- adjacent chunks and retrieval diagnostics add no model calls;
+- structural embedding changes set rebuild-required while the old active index remains queryable;
+- batch/slice/runtime-only changes do not invalidate compatible corpus vectors;
+- full rebuild uses staging + atomic activation and an interrupted staging rebuild resumes only after explicit Resume;
+- OCR, metadata, RAG chat and index slices continue to serialize through the shared `ai.lock`;
+- Paperless UI injection fails open and browser writes remain same-origin, authenticated and CSRF-protected;
+- chat history stays server-side and tests/examples use synthetic document content only.
+
+For a release candidate that changes the Paperless UI integration or RAG runtime, also run one short real deployment smoke test: open a current-document chat, retrieve at least one source, verify source navigation, and confirm the Control Center index state remains healthy.
+
 ## Paperless end-to-end checklist
 
 Use this checklist for a new Paperless/OCRmyPDF version or meaningful pipeline change:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -184,6 +184,51 @@ Runtime settings are loaded from `APP_DATA_DIR/config/app-config.json`.
 
 Deployment-owned values such as ports, mounts, HPI enablement, CPU/RAM/shared-memory limits and Paperless-side plugin environment require recreating/redeploying the affected containers.
 
+## Document chat button is missing
+
+Check the Paperless-side UI integration:
+
+- the shared integration directory is mounted read-only into Paperless;
+- `PYTHONPATH` includes `/opt/paperless-local-ai`;
+- `PAPERLESS_APPS` includes `paperless_local_ai_ui.apps.PaperlessLocalAiUiConfig`;
+- Paperless was restarted after changing the integration;
+- the Control Center reports the Paperless UI integration as ready/enabled;
+- the current Paperless user is a superuser.
+
+After a deployment/update, use a hard browser reload once to avoid testing an old cached asset. The integration fails open: if PLAI bootstrap cannot initialize, Paperless' own UI remains available instead of leaving a broken replacement.
+
+## Document chat is waiting for AI resources
+
+This is expected when OCR, metadata classification, another chat or an index slice currently owns the shared AI slot.
+
+The chat status reports the current owner/reason/elapsed time when available. `paperless-local-ai` deliberately serializes heavyweight work on modest hardware rather than loading multiple models or PaddleOCR concurrently.
+
+Do not delete `/coordination/ai.lock` while a real workload is running. The file lock is the synchronization primitive; `ai-status.json` is informational only.
+
+## RAG index build is slow
+
+A full embedding build is intentionally CPU-friendly rather than throughput-maximized. Current defaults are embedding batch `1` and slice `16`. On CPU-only hardware a non-trivial archive can take hours.
+
+The first build and every structural rebuild are explicit. Later rebuilds use `rag.db.build` while the old active index remains available. Pause/Resume is supported, and an interrupted staging build is retained.
+
+Increasing batch size is not guaranteed to make a limited CPU faster and can increase memory pressure. Benchmark before changing it.
+
+## RAG says rebuild required
+
+Structural corpus-embedding settings changed, but the active index is intentionally still serving its old compatible vectors.
+
+Typical rebuild-triggering changes include the embedding model, document embedding template, embedding dimensions/context behavior or chunk target/overlap. Start **Rebuild** under **Control Center → Document Chat → Index status** when you want those configured values to become active.
+
+Query-side/runtime settings such as retrieval history, source/answer prompt templates, adjacent chunks, diagnostics, batch/slice size or sync interval do not by themselves require a corpus rebuild.
+
+## RAG source metadata is empty or shows an ID
+
+Source metadata is read live from Paperless at chat time. A document can legitimately have no correspondent/document type/tags, in which case those template variables are empty.
+
+Related-object names are resolved from Paperless IDs. If a supplementary lookup fails, the RAG turn falls back rather than adding another AI dependency; some relation variables may therefore show an ID instead of a resolved name.
+
+The default source template does not use large fields such as full document content or raw JSON. Those variables exist for expert templates and can consume substantial context.
+
 ## Hybrid tagging does not reuse history
 
 A historical tag is reused only when the strict confidence gate passes. Check:
@@ -192,8 +237,8 @@ A historical tag is reused only when the strict confidence gate passes. Check:
 - human review is complete and the document used as history has had the configured review tag removed;
 - the document is not still in the classification queue/error state;
 - at least two reviewed neighbors support the same winning tag;
-- the nearest reviewed document has exactly one leaf content tag;
-- nearest similarity is at least 0.60 and weighted winner share is at least 0.50;
+- the winning complete reviewed leaf-tag set fits the configured maximum tag count;
+- nearest similarity reaches the configured gate (default 0.62), minimum support is met (default 2) and weighted winner share reaches the configured gate (default 0.50);
 - **Classification → Tagging → History health** is not reporting a refresh error.
 
 Use **Refresh reviewed history** after correcting historical tags if you want an immediate rebuild. The persistent UI/worker do not keep the scientific index in RAM; a Hybrid request starts the history helper on demand and a stale/invalid local cache is rebuilt automatically. If the Control Center reports that the history broker is unavailable, check the `core-service` container because it owns the lightweight broker. A fallback to the LLM is expected when the archive does not provide a sufficiently strong and internally consistent historical match.

--- a/docs/truenas.md
+++ b/docs/truenas.md
@@ -9,7 +9,8 @@ Tested reference: **TrueNAS SCALE 25.10.6**.
 You need:
 
 - working Paperless-ngx and Ollama services;
-- an installed Ollama model (`qwen3.5:4b` is the default);
+- an installed Ollama chat/classification model (`qwen3.5:4b` is the default);
+- if document chat is used, the default `qwen3-embedding:4b-q4_K_M` embedding model (or another configured embedding model);
 - a persistent TrueNAS dataset;
 - a Paperless API token;
 - a random OCR service token;
@@ -81,7 +82,7 @@ ocr-service
 core-service
 ```
 
-`core-service` hosts metadata polling, the Control Center, the suggestion-bridge endpoint and the lightweight History broker in one persistent Rust process. The scientific History engine remains an on-demand Python subprocess, while ports `30148` and `30149` stay unchanged.
+`core-service` hosts metadata polling, the Control Center, the suggestion-bridge endpoint, the lightweight History broker and RAG chat/index job orchestration in one persistent Rust process. The scientific History engine remains an on-demand Python subprocess, while ports `30148` and `30149` stay unchanged.
 
 ## 4. Configure the Control Center
 
@@ -143,7 +144,17 @@ Create the required metadata/review tags and a **Document Added** workflow that 
 
 OCR does not use a separate PaddleOCR queue tag. It happens inside Paperless import before the metadata workflow. See [Paperless setup](paperless-setup.md) for the complete review and matching configuration.
 
-## 7. Test one document
+## 7. Optional: enable document chat
+
+Document chat remains opt-in but is a first-class supported feature.
+
+Add the Paperless-side `PYTHONPATH` / `PAPERLESS_APPS` integration described in [Paperless setup](paperless-setup.md), restart Paperless, then enable the Paperless UI integration from the Control Center.
+
+Review **Control Center → Document Chat** and start the first RAG build explicitly under **Index status**. Paperless' native embedding backend can remain disabled/empty. The index lives in the existing persistent PLAI data mount and does not add a third long-running service.
+
+The defaults are intentionally conservative for CPU-only TrueNAS hosts: embedding batch `1`, slice `16`, 2000-character chunks with 400-character overlap. Full builds are expected to be much slower on CPU than on GPU hardware and can take hours; the active index remains available during later rebuilds and heavy work releases the shared AI slot between slices.
+
+## 8. Test one document
 
 Use a scanned PDF you can verify.
 


### PR DESCRIPTION
## Summary

Updates the project documentation after document chat/RAG became a first-class supported capability.

## Main changes

- presents OCR, metadata automation and document chat/RAG as the three core project capabilities
- reinforces the CPU-first / modest-hardware design goal
- documents the lightweight one-embed + one-chat RAG architecture
- updates current RAG defaults and Control Center ownership
- updates installation, TrueNAS, testing, troubleshooting and roadmap documentation
- removes outdated pre-RAG scope statements

No runtime code changes.