### PR TITLE
Fix Document Chat in browser demo

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -2,7 +2,8 @@
 
 The public Control Center demo is a static, browser-only build of the same UI source that ships in `core-service`.
 
-- All Paperless documents, taxonomy values, correspondents, History entries, OCR state and model results are synthetic fixtures.
+- All Paperless documents, taxonomy values, correspondents, History entries, OCR state, model results and RAG index state are synthetic fixtures.
+- Document Chat administration uses the public project RAG defaults plus index state derived only from the synthetic demo documents. Save, Sync, Rebuild and Pause/Resume affect browser-local demo state only.
 - `/api/...` calls are intercepted in the browser by `demo/mock-api.js`; no Paperless, Ollama or OCR backend is contacted.
 - The generated page sets `connect-src 'none'` so browser network requests from the demo are blocked.
 - Configuration changes and restore actions use browser `localStorage` only and can be cleared with **Reset demo**.

--- a/demo/mock-api.js
+++ b/demo/mock-api.js
@@ -5,8 +5,14 @@ const PROMPT_DEFAULT = __PROMPT_CONFIG_DEFAULT_JSON__;
 const PROMPT_PRESETS = __PROMPT_PRESETS_JSON__;
 const PLACEHOLDERS = __PLACEHOLDERS_JSON__;
 const APP_DEFAULT = __APP_CONFIG_DEFAULT_JSON__;
+const RAG_DEFAULT = __RAG_CONFIG_DEFAULT_JSON__;
+const RAG_PROMPT_PLACEHOLDERS = __RAG_PROMPT_PLACEHOLDERS_JSON__;
+const RAG_QUERY_PLACEHOLDERS = __RAG_QUERY_PLACEHOLDERS_JSON__;
+const RAG_DOCUMENT_PLACEHOLDERS = __RAG_DOCUMENT_PLACEHOLDERS_JSON__;
+const RAG_SOURCE_PLACEHOLDERS = __RAG_SOURCE_PLACEHOLDERS_JSON__;
+const RAG_ANSWER_PLACEHOLDERS = __RAG_ANSWER_PLACEHOLDERS_JSON__;
 
-const STORAGE_KEY = "paperless-local-ai-demo-v2";
+const STORAGE_KEY = "paperless-local-ai-demo-v3";
 
 const TAGS = [
   {id: 101, name: "Home", parent: null},
@@ -139,6 +145,161 @@ const clone = value => JSON.parse(JSON.stringify(value));
 const nowIso = () => new Date().toISOString();
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
+const RAG_SIGNATURE_KEYS = [
+  "embedding_model",
+  "chunk_target_chars",
+  "chunk_overlap_chars",
+  "document_embedding_template",
+  "embedding_dimensions",
+  "document_truncate",
+  "embedding_num_ctx"
+];
+
+function ragIndexSignature(config) {
+  const signature = {};
+  for (const key of RAG_SIGNATURE_KEYS) signature[key] = clone(config[key] ?? null);
+  return signature;
+}
+
+function normalizeRagConfig(raw) {
+  if (!raw || typeof raw !== "object") throw new Error("RAG configuration must be a JSON object.");
+  const incoming = clone(raw);
+  const candidate = {...clone(RAG_DEFAULT), ...incoming};
+  candidate.chat_defaults = {
+    ...clone(RAG_DEFAULT.chat_defaults || {}),
+    ...(incoming.chat_defaults || {})
+  };
+
+  if (!String(candidate.embedding_model || "").trim()) {
+    throw new Error("embedding_model must not be empty");
+  }
+  if (!String(candidate.chat_defaults.model || "").trim()) {
+    throw new Error("chat_defaults.model must not be empty");
+  }
+
+  return candidate;
+}
+
+function initialRagState(config) {
+  // This state is intentionally derived only from the synthetic DOCUMENTS
+  // fixture above. It must never mirror counts or timings from a real archive.
+  const documentCount = Object.keys(DOCUMENTS).length;
+  const stamp = nowIso();
+  return {
+    version: 1,
+    demo: true,
+    running: false,
+    paused: false,
+    operation: null,
+    phase: "idle",
+    current: documentCount,
+    total: documentCount,
+    indexed_documents: documentCount,
+    indexed_chunks: documentCount * 3,
+    last_sync: stamp,
+    last_build: stamp,
+    last_error: null,
+    rebuild_required: false,
+    index_exists: true,
+    active_signature: ragIndexSignature(config)
+  };
+}
+
+function saveRagConfig(raw) {
+  const candidate = normalizeRagConfig(raw);
+  state.ragConfig = candidate;
+
+  if (state.ragState?.index_exists) {
+    state.ragState.rebuild_required =
+      JSON.stringify(ragIndexSignature(candidate)) !==
+      JSON.stringify(state.ragState.active_signature || {});
+  }
+
+  persist();
+  return clone(candidate);
+}
+
+function ragBootstrap() {
+  return {
+    config: clone(state.ragConfig),
+    state: clone(state.ragState),
+    default_system_prompt: RAG_DEFAULT.system_prompt || "",
+    default_embedding_query_template: RAG_DEFAULT.embedding_query_template || "",
+    default_document_embedding_template: RAG_DEFAULT.document_embedding_template || "",
+    default_source_prompt_template: RAG_DEFAULT.source_prompt_template || "",
+    default_answer_prompt_template: RAG_DEFAULT.answer_prompt_template || "",
+    placeholders: clone(RAG_PROMPT_PLACEHOLDERS),
+    query_placeholders: clone(RAG_QUERY_PLACEHOLDERS),
+    document_placeholders: clone(RAG_DOCUMENT_PLACEHOLDERS),
+    source_placeholders: clone(RAG_SOURCE_PLACEHOLDERS),
+    answer_placeholders: clone(RAG_ANSWER_PLACEHOLDERS)
+  };
+}
+
+async function runDemoRagIndexAction(action) {
+  if (!["sync", "rebuild", "pause"].includes(action)) {
+    throw new Error("Unsupported demo RAG index action");
+  }
+
+  if (action === "pause") {
+    if (!state.ragState.paused) {
+      state.ragState.paused = true;
+      state.ragState.running = false;
+      persist();
+      return {paused: true, state: clone(state.ragState), simulated: true};
+    }
+
+    state.ragState.paused = false;
+    state.ragState.running = false;
+    state.ragState.operation = null;
+    state.ragState.phase = "idle";
+    state.ragState.last_sync = nowIso();
+    persist();
+    return {
+      paused: false,
+      started: true,
+      operation: "sync",
+      simulated: true
+    };
+  }
+
+  if (action === "sync" && state.ragState.rebuild_required) {
+    throw new Error("index settings changed; rebuild required before sync");
+  }
+
+  if (state.ragState.paused) {
+    throw new Error("demo RAG index is paused");
+  }
+
+  state.ragState.running = true;
+  state.ragState.operation = action;
+  state.ragState.phase = action === "rebuild" ? "rebuilding" : "syncing";
+  persist();
+
+  await sleep(250);
+
+  const documentCount = Object.keys(DOCUMENTS).length;
+  state.ragState.running = false;
+  state.ragState.operation = null;
+  state.ragState.phase = "idle";
+  state.ragState.current = documentCount;
+  state.ragState.total = documentCount;
+  state.ragState.index_exists = true;
+  state.ragState.indexed_documents = documentCount;
+  state.ragState.indexed_chunks = documentCount * 3;
+  state.ragState.last_sync = nowIso();
+  state.ragState.last_error = null;
+
+  if (action === "rebuild") {
+    state.ragState.last_build = nowIso();
+    state.ragState.active_signature = ragIndexSignature(state.ragConfig);
+    state.ragState.rebuild_required = false;
+  }
+
+  persist();
+  return {started: true, simulated: true};
+}
+
 function initialState() {
   const promptConfig = clone(PROMPT_DEFAULT);
   promptConfig.version = 3;
@@ -157,9 +318,14 @@ function initialState() {
   appConfig.ocr.language = "en";
   appConfig.ocr.model_profile = "medium";
 
+  const ragConfig = normalizeRagConfig(RAG_DEFAULT);
+  const ragState = initialRagState(ragConfig);
+
   return {
     promptConfig,
     appConfig,
+    ragConfig,
+    ragState,
     promptHistory: [
       {
         file: "prompt-config-v0002-demo.json",
@@ -672,6 +838,24 @@ async function api(path, opts = {}) {
   if (path === "/api/app/ocr/recovery" && method === "GET") return ocrRecovery();
   if (path === "/api/app/ocr/failures/dismiss" && method === "POST") return {ok: true, removed: false};
   if (path === "/api/app/ocr/retry-now" && method === "POST") return {ok: true, trigger: {request_id: body.request_id || "", simulated: true}};
+
+  if (path === "/api/control/rag/bootstrap" && method === "GET") {
+    return ragBootstrap();
+  }
+  if (path === "/api/control/rag/config" && method === "POST") {
+    const config = saveRagConfig(body);
+    return {config, state: clone(state.ragState), simulated: true};
+  }
+  if (path === "/api/control/rag/index/sync" && method === "POST") {
+    return runDemoRagIndexAction("sync");
+  }
+  if (path === "/api/control/rag/index/rebuild" && method === "POST") {
+    return runDemoRagIndexAction("rebuild");
+  }
+  if (path === "/api/control/rag/index/pause" && method === "POST") {
+    return runDemoRagIndexAction("pause");
+  }
+
   if (path === "/api/health" && method === "GET") return {ok: true, demo: true};
 
   throw new Error(`Demo endpoint is not implemented: ${method} ${path}`);

--- a/scripts/build_demo.py
+++ b/scripts/build_demo.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import ast
 import json
+import re
 from pathlib import Path
 
 HTML_START = "HTML = r'''"
@@ -91,6 +92,34 @@ def js_json(value: object) -> str:
     return json.dumps(value, ensure_ascii=False, separators=(",", ":")).replace("</", "<\\/")
 
 
+def rust_raw_json_const(source: str, name: str) -> object:
+    match = re.search(
+        rf'const\s+{re.escape(name)}\s*:\s*&str\s*=\s*r#"(.*?)"#;',
+        source,
+        re.DOTALL,
+    )
+    if not match:
+        raise SystemExit(f"Could not read Rust raw JSON constant: {name}")
+    try:
+        return json.loads(match.group(1))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Rust JSON constant {name} is invalid JSON: {exc}") from exc
+
+
+def rust_string_array_const(source: str, name: str) -> list[str]:
+    match = re.search(
+        rf'const\s+{re.escape(name)}\s*:\s*&\s*\[&str\]\s*=\s*&\s*\[(.*?)\]\s*;',
+        source,
+        re.DOTALL,
+    )
+    if not match:
+        raise SystemExit(f"Could not read Rust string-array constant: {name}")
+    values = re.findall(r'"([^"]+)"', match.group(1))
+    if not values:
+        raise SystemExit(f"Rust string-array constant is empty: {name}")
+    return values
+
+
 def extract_control_center(source: Path) -> str:
     text = source.read_text(encoding="utf-8")
     start = text.find(HTML_START)
@@ -121,6 +150,7 @@ def render_mock_source(repo: Path) -> str:
 
     prompt_constants = source_constants(repo / "src" / "core" / "prompt_runtime.py")
     app_constants = source_constants(repo / "src" / "common" / "app_config.py")
+    rag_source = (repo / "rust" / "core" / "src" / "rag.rs").read_text(encoding="utf-8")
 
     required_prompt = ["DEFAULT_CONFIG", "PROMPT_PRESETS", "PLACEHOLDERS"]
     missing_prompt = [name for name in required_prompt if name not in prompt_constants]
@@ -129,11 +159,24 @@ def render_mock_source(repo: Path) -> str:
     if "DEFAULT_CONFIG" not in app_constants:
         raise SystemExit("Could not statically read App Settings defaults")
 
+    rag_default = rust_raw_json_const(rag_source, "DEFAULT_RAG_CONFIG")
+    rag_prompt_placeholders = rust_string_array_const(rag_source, "RAG_PROMPT_PLACEHOLDERS")
+    rag_query_placeholders = rust_string_array_const(rag_source, "EMBEDDING_QUERY_PLACEHOLDERS")
+    rag_document_placeholders = rust_string_array_const(rag_source, "DOCUMENT_EMBEDDING_PLACEHOLDERS")
+    rag_source_placeholders = rust_string_array_const(rag_source, "SOURCE_PROMPT_PLACEHOLDERS")
+    rag_answer_placeholders = rust_string_array_const(rag_source, "ANSWER_PROMPT_PLACEHOLDERS")
+
     replacements = {
         "__PROMPT_CONFIG_DEFAULT_JSON__": js_json(prompt_constants["DEFAULT_CONFIG"]),
         "__PROMPT_PRESETS_JSON__": js_json(prompt_constants["PROMPT_PRESETS"]),
         "__PLACEHOLDERS_JSON__": js_json(prompt_constants["PLACEHOLDERS"]),
         "__APP_CONFIG_DEFAULT_JSON__": js_json(app_constants["DEFAULT_CONFIG"]),
+        "__RAG_CONFIG_DEFAULT_JSON__": js_json(rag_default),
+        "__RAG_PROMPT_PLACEHOLDERS_JSON__": js_json(rag_prompt_placeholders),
+        "__RAG_QUERY_PLACEHOLDERS_JSON__": js_json(rag_query_placeholders),
+        "__RAG_DOCUMENT_PLACEHOLDERS_JSON__": js_json(rag_document_placeholders),
+        "__RAG_SOURCE_PLACEHOLDERS_JSON__": js_json(rag_source_placeholders),
+        "__RAG_ANSWER_PLACEHOLDERS_JSON__": js_json(rag_answer_placeholders),
     }
     for marker, value in replacements.items():
         if marker not in mock:

--- a/tests/test_demo_build.py
+++ b/tests/test_demo_build.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -35,6 +36,17 @@ def test_static_control_center_demo_builds(tmp_path):
     assert "__TAGGING_DOCS_URL__" not in html
     assert "__PAPERLESS_SETUP_DOCS_URL__" not in html
     assert "__APP_VERSION__" not in html
+    assert "__RAG_CONFIG_DEFAULT_JSON__" not in html
+    assert "__RAG_PROMPT_PLACEHOLDERS_JSON__" not in html
+    assert "__RAG_QUERY_PLACEHOLDERS_JSON__" not in html
+    assert "__RAG_DOCUMENT_PLACEHOLDERS_JSON__" not in html
+    assert "__RAG_SOURCE_PLACEHOLDERS_JSON__" not in html
+    assert "__RAG_ANSWER_PLACEHOLDERS_JSON__" not in html
+    assert 'path === "/api/control/rag/bootstrap"' in html
+    assert 'path === "/api/control/rag/config"' in html
+    assert 'path === "/api/control/rag/index/sync"' in html
+    assert 'path === "/api/control/rag/index/rebuild"' in html
+    assert 'path === "/api/control/rag/index/pause"' in html
 
 
 def test_demo_mock_has_no_network_client():
@@ -42,3 +54,42 @@ def test_demo_mock_has_no_network_client():
     assert "fetch(" not in source
     assert "XMLHttpRequest" not in source
     assert "WebSocket(" not in source
+
+
+def test_demo_rag_state_uses_only_synthetic_fixtures():
+    source = (ROOT / "demo" / "mock-api.js").read_text(encoding="utf-8")
+
+    # RAG configuration comes from public project defaults at demo build time.
+    assert "const RAG_DEFAULT = __RAG_CONFIG_DEFAULT_JSON__;" in source
+
+    # Demo index state is derived exclusively from the existing synthetic
+    # DOCUMENTS fixture, never from real archive counts or copied runtime state.
+    assert "const documentCount = Object.keys(DOCUMENTS).length;" in source
+    assert "indexed_documents: documentCount" in source
+    assert "indexed_chunks: documentCount * 3" in source
+    assert "demo: true" in source
+    assert "last_sync: stamp" in source
+    assert "last_build: stamp" in source
+
+    # Never copy archive-specific counts into the public demo.
+    assert re.search(r"indexed_(?:documents|chunks)\\s*:\\s*\\d+", source) is None
+
+    # Never embed a private LAN address from a real installation.
+    private_ipv4 = re.compile(
+        r"\\b(?:"
+        r"10(?:\\.\\d{1,3}){3}|"
+        r"192\\.168(?:\\.\\d{1,3}){2}|"
+        r"172\\.(?:1[6-9]|2\\d|3[01])(?:\\.\\d{1,3}){2}"
+        r")\\b"
+    )
+    assert private_ipv4.search(source) is None
+
+    # All Control Center RAG admin calls are handled by the browser-only mock.
+    for endpoint in (
+        "/api/control/rag/bootstrap",
+        "/api/control/rag/config",
+        "/api/control/rag/index/sync",
+        "/api/control/rag/index/rebuild",
+        "/api/control/rag/index/pause",
+    ):
+        assert endpoint in source


### PR DESCRIPTION
Updates the browser-only demo for the Document Chat/RAG administration added in 0.5.0.

- mocks the Control Center RAG endpoints
- derives RAG defaults from the production Rust source
- uses synthetic demo-only RAG index state
- simulates Save, Sync, Rebuild and Pause/Resume locally in the browser
- adds regression checks for the RAG demo
- prevents archive-specific counts and private LAN addresses from being embedded in the demo